### PR TITLE
Add node control panel

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -16,9 +16,16 @@
         <v-list-item-content>
           <v-list-item-title>{{ node.name }}</v-list-item-title>
           <v-list-item-subtitle class="text-wrap text-body-2">
-            {{ node.location }} — Voltaje: {{ node.voltage ?? 'N/A' }} V — Corriente: {{ node.current ?? 'N/A' }} A
+            {{ node.location }} — RSSI: {{ node.rssi ?? 'N/A' }} — Voltaje: {{ node.voltage ?? 'N/A' }} V — Corriente: {{ node.current ?? 'N/A' }} A
           </v-list-item-subtitle>
         </v-list-item-content>
+        <v-list-item-action>
+          <v-switch
+            v-model="node.state"
+            @change="toggleNode(node)"
+            inset
+          ></v-switch>
+        </v-list-item-action>
       </v-list-item>
 
       <v-divider class="my-2"></v-divider>
@@ -54,11 +61,22 @@ const name = ref('')
 const location = ref('')
 const identifier = ref('')
 
+// Cambiar estado del nodo
+const toggleNode = async (node) => {
+  try {
+    await api.post(`/nodes/${node.identifier}/state`, {
+      state: node.state ? 1 : 0,
+    })
+  } catch (err) {
+    console.error('❌ Error al actualizar estado:', err)
+  }
+}
+
 // Cargar nodos
 const fetchNodes = async () => {
   try {
     const res = await api.get('/nodes')
-    nodes.value = res.data
+    nodes.value = res.data.map(n => ({ ...n, state: Boolean(n.state) }))
   } catch (err) {
     console.error('❌ Error al cargar nodos:', err)
   }

--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col v-for="node in nodes" :key="node.id" cols="12" sm="6" md="4">
+        <v-card class="ma-2">
+          <v-card-title>{{ node.name }}</v-card-title>
+          <v-card-text>
+            <div>RSSI: {{ node.rssi ?? 'N/A' }}</div>
+            <div>Voltaje: {{ node.voltage ?? 'N/A' }} V</div>
+            <div>Corriente: {{ node.current ?? 'N/A' }} A</div>
+            <v-switch
+              v-model="node.state"
+              @change="toggleNode(node)"
+              class="mt-2"
+              :label="node.state ? 'Encendido' : 'Apagado'"
+            ></v-switch>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import api from '@/plugins/axios'
+
+const nodes = ref([])
+
+const fetchNodes = async () => {
+  try {
+    const res = await api.get('/nodes')
+    nodes.value = res.data.map(n => ({ ...n, state: Boolean(n.state) }))
+  } catch (err) {
+    console.error('❌ Error al cargar nodos:', err)
+  }
+}
+
+const toggleNode = async (node) => {
+  try {
+    await api.post(`/nodes/${node.identifier}/state`, {
+      state: node.state ? 1 : 0,
+    })
+  } catch (err) {
+    console.error('❌ Error al actualizar estado:', err)
+  }
+}
+
+onMounted(fetchNodes)
+
+onMounted(() => {
+  const socket = new WebSocket('ws://3.66.72.52:3010')
+  socket.addEventListener('message', () => {
+    fetchNodes()
+  })
+})
+</script>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -20,4 +20,7 @@ export const getNodes = (token) =>
 export const recoverPassword = (email) =>
   api.post('/api/recover', { email })
 
+export const toggleNodeState = (identifier, state) =>
+  api.post(`/nodes/${identifier}/state`, { state })
+
 export default api

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,8 +4,7 @@
 
     <v-main>
       <v-container>
-        <h1>Bienvenido al Panel de Control</h1>
-        <p>Aquí irá el contenido principal más adelante.</p>
+        <NodePanel />
       </v-container>
     </v-main>
   </v-app>
@@ -13,5 +12,6 @@
 
 <script setup>
 import NodeDrawer from '@/components/NodeDrawer.vue'
+import NodePanel from '@/components/NodePanel.vue'
 </script>
 


### PR DESCRIPTION
## Summary
- show node RSSI and allow power toggle in NodeDrawer
- add NodePanel to dashboard showing full node status
- support new `/nodes/:identifier/state` endpoint and RSSI field
- send RSSI over WebSocket and handle updates

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in frontend *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6843f0125374832eac2c5a0465090141