### PR TITLE
Improve dashboard UI with collapsible drawer

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -1,5 +1,9 @@
 <template>
-  <v-navigation-drawer app permanent>
+  <v-navigation-drawer
+    v-model="localOpen"
+    app
+    temporary
+  >
     <v-list>
       <v-list-item>
         <v-list-item-title class="text-h6">Tus Nodos</v-list-item-title>
@@ -59,15 +63,27 @@
 </template>
 
 <script setup>
-import { ref, defineProps, defineEmits } from 'vue'
+import { ref, watch, defineProps, defineEmits } from 'vue'
 import api from '@/plugins/axios'
 
 const props = defineProps({
+  modelValue: { type: Boolean, default: true },
   nodes: { type: Array, default: () => [] },
   panelNodes: { type: Array, default: () => [] }
 })
 
-const emit = defineEmits(['add', 'remove', 'refresh'])
+const emit = defineEmits(['add', 'remove', 'refresh', 'update:modelValue'])
+
+const localOpen = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  val => {
+    localOpen.value = val
+  }
+)
+
+watch(localOpen, val => emit('update:modelValue', val))
 
 const dialog = ref(false)
 const name = ref('')

--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -3,18 +3,39 @@
     <v-row>
       <v-col v-for="node in nodes" :key="node.id" cols="12" sm="6" md="4">
         <v-card class="ma-2">
-          <v-card-title>{{ node.name }}</v-card-title>
-          <v-card-text>
-            <div>RSSI: {{ node.rssi ?? 'N/A' }}</div>
-            <div>Voltaje: {{ node.voltage ?? 'N/A' }} V</div>
-            <div>Corriente: {{ node.current ?? 'N/A' }} A</div>
+          <v-card-title class="d-flex justify-space-between">
+            {{ node.name }}
             <v-switch
               v-model="node.state"
               @change="toggleNode(node)"
-              class="mt-2"
               :label="node.state ? 'Encendido' : 'Apagado'"
+              hide-details
             ></v-switch>
-          </v-card-text>
+          </v-card-title>
+          <v-divider></v-divider>
+          <v-list density="compact">
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-signal</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>RSSI</v-list-item-title>
+              <v-list-item-subtitle>{{ node.rssi ?? 'N/A' }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-flash</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Voltaje</v-list-item-title>
+              <v-list-item-subtitle>{{ node.voltage ?? 'N/A' }} V</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-current-ac</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Corriente</v-list-item-title>
+              <v-list-item-subtitle>{{ node.current ?? 'N/A' }} A</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
         </v-card>
       </v-col>
     </v-row>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,12 +1,22 @@
 <template>
   <v-app>
     <NodeDrawer
+      v-model="drawer"
       :nodes="nodes"
       :panel-nodes="panelNodes"
       @add="addToPanel"
       @remove="removeFromPanel"
       @refresh="fetchNodes"
     />
+
+    <v-btn
+      icon
+      class="ma-2"
+      style="position: fixed; top: 80px; left: 10px; z-index: 1000;"
+      @click="drawer = !drawer"
+    >
+      <v-icon>{{ drawer ? 'mdi-menu-open' : 'mdi-menu' }}</v-icon>
+    </v-btn>
 
     <v-main>
       <v-container>
@@ -24,6 +34,7 @@ import api from '@/plugins/axios'
 
 const nodes = ref([])
 const panelNodes = ref([])
+const drawer = ref(false)
 
 const fetchNodes = async () => {
   try {


### PR DESCRIPTION
## Summary
- allow NodeDrawer to be toggled open/closed
- redesign NodePanel cards with icons for RSSI, voltage and current
- add floating menu button in DashboardView to toggle drawer

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68446095c19c832eb2699a3288cc581a