### PR TITLE
Customize dashboard layout and header

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -161,7 +161,7 @@ db.get(`SELECT * FROM users WHERE username = ?`, [username], (err, user) => {
     }
 
     const token = jwt.sign({ id: user.id }, SECRET, { expiresIn: '1d' });
-    res.send({ token });
+    res.send({ token, username: user.username });
 });
 
 });

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -3,9 +3,10 @@
     <v-app-bar app>
       <v-toolbar-title>LoRa Control</v-toolbar-title>
       <v-spacer></v-spacer>
-      <v-btn text to="/">Inicio</v-btn>
-      <v-btn text to="/login">Login</v-btn>
-      <v-btn text to="/register">Registro</v-btn>
+      <v-btn text v-if="!loggedIn" to="/">Inicio</v-btn>
+      <v-btn text v-if="!loggedIn" to="/login">Login</v-btn>
+      <v-btn text v-if="!loggedIn" to="/register">Registro</v-btn>
+      <span v-else class="mr-4">Bienvenido, {{ username }}</span>
 
       <v-menu offset-y>
         <template #activator="{ props }">
@@ -32,10 +33,23 @@
 </template>
 
 <script setup>
-import { ref, provide } from 'vue'
+import { ref, provide, onMounted } from 'vue'
 
 const selectedLang = ref('es')
 provide('lang', selectedLang)
+
+const username = ref('')
+const loggedIn = ref(false)
+
+const updateAuth = () => {
+  username.value = localStorage.getItem('username') || ''
+  loggedIn.value = Boolean(localStorage.getItem('token'))
+}
+
+onMounted(() => {
+  updateAuth()
+  window.addEventListener('auth-changed', updateAuth)
+})
 
 const changeLang = (lang) => {
   selectedLang.value = lang

--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -1,5 +1,10 @@
 <template>
-  <v-navigation-drawer app permanent>
+  <v-navigation-drawer
+    v-model="localOpen"
+    app
+    temporary
+    style="overflow-y:auto"
+  >
     <v-list>
       <v-list-item>
         <v-list-item-title class="text-h6">Tus Nodos</v-list-item-title>
@@ -59,15 +64,27 @@
 </template>
 
 <script setup>
-import { ref, defineProps, defineEmits } from 'vue'
+import { ref, watch, defineProps, defineEmits } from 'vue'
 import api from '@/plugins/axios'
 
 const props = defineProps({
+  modelValue: { type: Boolean, default: true },
   nodes: { type: Array, default: () => [] },
   panelNodes: { type: Array, default: () => [] }
 })
 
-const emit = defineEmits(['add', 'remove', 'refresh'])
+const emit = defineEmits(['add', 'remove', 'refresh', 'update:modelValue'])
+
+const localOpen = ref(props.modelValue)
+
+watch(
+  () => props.modelValue,
+  val => {
+    localOpen.value = val
+  }
+)
+
+watch(localOpen, val => emit('update:modelValue', val))
 
 const dialog = ref(false)
 const name = ref('')

--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -1,20 +1,41 @@
 <template>
   <v-container>
     <v-row>
-      <v-col v-for="node in nodes" :key="node.id" cols="12" sm="6" md="4">
+      <v-col v-for="node in nodes" :key="node.id" cols="12" :sm="columnSpan" :md="columnSpan">
         <v-card class="ma-2">
-          <v-card-title>{{ node.name }}</v-card-title>
-          <v-card-text>
-            <div>RSSI: {{ node.rssi ?? 'N/A' }}</div>
-            <div>Voltaje: {{ node.voltage ?? 'N/A' }} V</div>
-            <div>Corriente: {{ node.current ?? 'N/A' }} A</div>
+          <v-card-title class="d-flex justify-space-between">
+            {{ node.name }}
             <v-switch
               v-model="node.state"
               @change="toggleNode(node)"
-              class="mt-2"
               :label="node.state ? 'Encendido' : 'Apagado'"
+              hide-details
             ></v-switch>
-          </v-card-text>
+          </v-card-title>
+          <v-divider></v-divider>
+          <v-list density="compact">
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-signal</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>RSSI</v-list-item-title>
+              <v-list-item-subtitle>{{ node.rssi ?? 'N/A' }}</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-flash</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Voltaje</v-list-item-title>
+              <v-list-item-subtitle>{{ node.voltage ?? 'N/A' }} V</v-list-item-subtitle>
+            </v-list-item>
+            <v-list-item>
+              <v-list-item-icon>
+                <v-icon color="primary">mdi-current-ac</v-icon>
+              </v-list-item-icon>
+              <v-list-item-title>Corriente</v-list-item-title>
+              <v-list-item-subtitle>{{ node.current ?? 'N/A' }} A</v-list-item-subtitle>
+            </v-list-item>
+          </v-list>
         </v-card>
       </v-col>
     </v-row>
@@ -22,11 +43,14 @@
 </template>
 
 <script setup>
-import { defineProps, defineEmits } from 'vue'
+import { defineProps, defineEmits, computed } from 'vue'
 
 const props = defineProps({
-  nodes: { type: Array, default: () => [] }
+  nodes: { type: Array, default: () => [] },
+  perRow: { type: Number, default: 3 }
 })
+
+const columnSpan = computed(() => Math.floor(12 / props.perRow))
 
 const emit = defineEmits(['toggle'])
 

--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -1,0 +1,40 @@
+<template>
+  <v-dialog v-model="localOpen" max-width="400">
+    <v-card>
+      <v-card-title>Panel Settings</v-card-title>
+      <v-card-text>
+        <v-slider
+          v-model="localCols"
+          :min="1"
+          :max="4"
+          step="1"
+          thumb-label
+          label="Nodos por fila"
+        ></v-slider>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn text @click="localOpen = false">Cerrar</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup>
+import { ref, watch, defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+  cols: { type: Number, default: 3 }
+})
+
+const emit = defineEmits(['update:modelValue', 'update:cols'])
+
+const localOpen = ref(props.modelValue)
+const localCols = ref(props.cols)
+
+watch(() => props.modelValue, v => (localOpen.value = v))
+watch(() => props.cols, v => (localCols.value = v))
+watch(localOpen, v => emit('update:modelValue', v))
+watch(localCols, v => emit('update:cols', v))
+</script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
     <NodeDrawer
+      v-model="drawer"
       :nodes="nodes"
       :panel-nodes="panelNodes"
       @add="addToPanel"
@@ -8,9 +9,29 @@
       @refresh="fetchNodes"
     />
 
+<v-btn
+      icon
+      class="ma-2"
+      :style="{ position: 'fixed', top: '80px', left: drawer ? '240px' : '10px', zIndex: 1000 }"
+      @click="drawer = !drawer"
+    >
+      <v-icon>{{ drawer ? 'mdi-menu-open' : 'mdi-menu' }}</v-icon>
+    </v-btn>
+
+    <v-btn
+      icon
+      class="ma-2"
+      :style="{ position: 'fixed', top: '80px', right: '10px', zIndex: 1000 }"
+      @click="settingsOpen = true"
+    >
+      <v-icon>mdi-cog</v-icon>
+    </v-btn>
+
+    <PanelSettings v-model="settingsOpen" :cols="perRow" @update:cols="perRow = $event" />
+
     <v-main>
       <v-container>
-        <NodePanel :nodes="panelNodes" @toggle="toggleNode" />
+        <NodePanel :nodes="panelNodes" :per-row="perRow" @toggle="toggleNode" />
       </v-container>
     </v-main>
   </v-app>
@@ -19,11 +40,17 @@
 <script setup>
 import NodeDrawer from '@/components/NodeDrawer.vue'
 import NodePanel from '@/components/NodePanel.vue'
-import { ref, onMounted } from 'vue'
+import PanelSettings from '@/components/PanelSettings.vue'
+import { ref, onMounted, watch } from 'vue'
 import api from '@/plugins/axios'
 
 const nodes = ref([])
 const panelNodes = ref([])
+const drawer = ref(false)
+const settingsOpen = ref(false)
+const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
+
+watch(perRow, val => localStorage.setItem('perRow', val))
 
 const fetchNodes = async () => {
   try {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -111,6 +111,8 @@ const doLogin = async () => {
   try {
     const res = await login(username.value, password.value)
     localStorage.setItem('token', res.data.token)
+    localStorage.setItem('username', res.data.username)
+    window.dispatchEvent(new Event('auth-changed'))
     router.push('/dashboard')
   } catch (err) {
     error.value = err.response?.data?.error || 'Error al iniciar sesión'


### PR DESCRIPTION
## Summary
- show logged-in username in app bar and hide login/register links
- allow customizing node panel columns via new PanelSettings dialog
- reposition menu toggle button when drawer is open
- make drawer scrollable independently
- return username from login API and store it on login

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68446095c19c832eb2699a3288cc581a