### PR TITLE
Add logout and dashboard persistence

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,7 +6,22 @@
       <v-btn text v-if="!loggedIn" to="/">Inicio</v-btn>
       <v-btn text v-if="!loggedIn" to="/login">Login</v-btn>
       <v-btn text v-if="!loggedIn" to="/register">Registro</v-btn>
-      <span v-else class="mr-4">Bienvenido, {{ username }}</span>
+      <v-menu v-else offset-y>
+        <template #activator="{ props }">
+          <v-btn v-bind="props" text>
+            Bienvenido, {{ username }}
+            <v-icon end>mdi-chevron-down</v-icon>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-item to="/profile">
+            <v-list-item-title>Perfil</v-list-item-title>
+          </v-list-item>
+          <v-list-item @click="logout">
+            <v-list-item-title>Cerrar sesión</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
 
       <v-menu offset-y>
         <template #activator="{ props }">
@@ -34,12 +49,14 @@
 
 <script setup>
 import { ref, provide, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 
 const selectedLang = ref('es')
 provide('lang', selectedLang)
 
 const username = ref('')
 const loggedIn = ref(false)
+const router = useRouter()
 
 const updateAuth = () => {
   username.value = localStorage.getItem('username') || ''
@@ -53,5 +70,13 @@ onMounted(() => {
 
 const changeLang = (lang) => {
   selectedLang.value = lang
+}
+
+const logout = () => {
+  localStorage.removeItem('token')
+  localStorage.removeItem('username')
+  updateAuth()
+  window.dispatchEvent(new Event('auth-changed'))
+  router.push('/login')
 }
 </script>

--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -2,7 +2,7 @@
   <v-dialog v-model="localOpen" max-width="400">
     <v-card>
       <v-card-title>Panel Settings</v-card-title>
-      <v-card-text>
+  <v-card-text>
         <v-slider
           v-model="localCols"
           :min="1"
@@ -11,6 +11,28 @@
           thumb-label
           label="Nodos por fila"
         ></v-slider>
+
+        <v-text-field
+          v-model="dashboardName"
+          label="Nombre del dashboard"
+          class="mt-4"
+        ></v-text-field>
+        <v-btn color="primary" class="mt-2" @click="save">Guardar actual</v-btn>
+
+        <v-select
+          v-model="selectedDash"
+          :items="props.dashboards"
+          label="Dashboards guardados"
+          class="mt-4"
+        ></v-select>
+        <v-btn class="mt-2" @click="load">Cargar</v-btn>
+
+        <v-select
+          v-model="defaultDashLocal"
+          :items="props.dashboards"
+          label="Dashboard por defecto"
+          class="mt-4"
+        ></v-select>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>
@@ -25,16 +47,45 @@ import { ref, watch, defineProps, defineEmits } from 'vue'
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
-  cols: { type: Number, default: 3 }
+  cols: { type: Number, default: 3 },
+  dashboards: { type: Array, default: () => [] },
+  defaultDash: { type: String, default: '' }
 })
 
-const emit = defineEmits(['update:modelValue', 'update:cols'])
+const emit = defineEmits([
+  'update:modelValue',
+  'update:cols',
+  'save-dashboard',
+  'load-dashboard',
+  'update:defaultDash'
+])
 
 const localOpen = ref(props.modelValue)
 const localCols = ref(props.cols)
+const dashboardName = ref('')
+const selectedDash = ref(props.defaultDash)
+const defaultDashLocal = ref(props.defaultDash)
 
 watch(() => props.modelValue, v => (localOpen.value = v))
 watch(() => props.cols, v => (localCols.value = v))
+watch(() => props.defaultDash, v => {
+  selectedDash.value = v
+  defaultDashLocal.value = v
+})
 watch(localOpen, v => emit('update:modelValue', v))
 watch(localCols, v => emit('update:cols', v))
+watch(defaultDashLocal, v => emit('update:defaultDash', v))
+
+const save = () => {
+  if (dashboardName.value) {
+    emit('save-dashboard', dashboardName.value)
+    dashboardName.value = ''
+  }
+}
+
+const load = () => {
+  if (selectedDash.value) {
+    emit('load-dashboard', selectedDash.value)
+  }
+}
 </script>

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -1,10 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import LoginView from '../views/LoginView.vue'
 import DashboardView from '../views/DashboardView.vue'
-import Register from '../views/Register.vue' 
+import Register from '../views/Register.vue'
 import LandingView from '../views/LandingView.vue'
 import Recover from '../views/Recover.vue'
 import ResetPassword from '../views/ResetPassword.vue'
+import ProfileView from '../views/ProfileView.vue'
 
 const routes = [
 { path: '/', name: 'Landing', component: LandingView },
@@ -12,7 +13,8 @@ const routes = [
   { path: '/dashboard', component: DashboardView },
   { path: '/register', component: Register },
   { path: '/recover', component: Recover },
-  { path: '/reset', component: ResetPassword }
+  { path: '/reset', component: ResetPassword },
+  { path: '/profile', component: ProfileView }
 ]
 
 const router = createRouter({

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -27,7 +27,16 @@
   <v-icon>mdi-cog</v-icon>
 </v-btn>
 
-<PanelSettings v-model="settingsOpen" :cols="perRow" @update:cols="perRow = $event" />
+<PanelSettings
+  v-model="settingsOpen"
+  :cols="perRow"
+  :dashboards="Object.keys(dashboards.layouts)"
+  :default-dash="dashboards.default"
+  @update:cols="perRow = $event"
+  @save-dashboard="saveDashboard"
+  @load-dashboard="loadDashboard"
+  @update:defaultDash="(val) => { dashboards.default = val; selectedDashboard.value = val }"
+/>
     <v-main>
       <v-container>
         <NodePanel :nodes="panelNodes" :per-row="perRow" @toggle="toggleNode" />
@@ -48,13 +57,21 @@ const panelNodes = ref([])
 const drawer = ref(false)
 const settingsOpen = ref(false)
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
+const dashboards = ref(JSON.parse(localStorage.getItem('dashboards') || '{"default":"","layouts":{}}'))
+const selectedDashboard = ref(dashboards.value.default || '')
 
 watch(perRow, val => localStorage.setItem('perRow', val))
+watch(dashboards, val => localStorage.setItem('dashboards', JSON.stringify(val)), { deep: true })
 
+let firstLoad = true
 const fetchNodes = async () => {
   try {
     const res = await api.get('/nodes')
     nodes.value = res.data.map(n => ({ ...n, state: Boolean(n.state) }))
+    if (firstLoad && selectedDashboard.value) {
+      loadDashboard(selectedDashboard.value)
+      firstLoad = false
+    }
   } catch (err) {
     console.error('❌ Error al cargar nodos:', err)
   }
@@ -70,6 +87,12 @@ const removeFromPanel = (node) => {
   panelNodes.value = panelNodes.value.filter(n => n.id !== node.id)
 }
 
+watch(panelNodes, () => {
+  if (selectedDashboard.value) {
+    dashboards.value.layouts[selectedDashboard.value] = panelNodes.value.map(n => n.id)
+  }
+}, { deep: true })
+
 const toggleNode = async (node) => {
   try {
     await api.post(`/nodes/${node.identifier}/state`, {
@@ -78,6 +101,19 @@ const toggleNode = async (node) => {
   } catch (err) {
     console.error('❌ Error al actualizar estado:', err)
   }
+}
+
+const saveDashboard = (name) => {
+  dashboards.value.layouts[name] = panelNodes.value.map(n => n.id)
+  dashboards.value.default = name
+  selectedDashboard.value = name
+}
+
+const loadDashboard = (name) => {
+  selectedDashboard.value = name
+  dashboards.value.default = name
+  const ids = dashboards.value.layouts[name] || []
+  panelNodes.value = ids.map(id => nodes.value.find(n => n.id === id)).filter(Boolean)
 }
 
 onMounted(() => {

--- a/frontend/src/views/ProfileView.vue
+++ b/frontend/src/views/ProfileView.vue
@@ -1,0 +1,16 @@
+<template>
+  <v-container class="pa-4">
+    <h2>Perfil de usuario</h2>
+    <p>Usuario: {{ username }}</p>
+  </v-container>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const username = ref('')
+
+onMounted(() => {
+  username.value = localStorage.getItem('username') || ''
+})
+</script>


### PR DESCRIPTION
## Summary
- create profile page
- show user dropdown with profile & logout
- allow dashboard layouts to be saved/loaded and persisted

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68451d19af3c832eb69f01e4ac97bd1c