### PR TITLE
Add right navigation drawer with node list

### DIFF
--- a/frontend/src/components/NodeList.vue
+++ b/frontend/src/components/NodeList.vue
@@ -1,0 +1,20 @@
+<template>
+  <v-container>
+    <v-list>
+      <v-list-item v-for="node in nodes" :key="node.id">
+        <v-list-item-content>
+          <v-list-item-title>{{ node.name }}</v-list-item-title>
+          <v-list-item-subtitle>{{ node.identifier }}</v-list-item-subtitle>
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
+  </v-container>
+</template>
+
+<script setup>
+import { defineProps } from 'vue'
+
+const props = defineProps({
+  nodes: { type: Array, default: () => [] }
+})
+</script>

--- a/frontend/src/components/RightNav.vue
+++ b/frontend/src/components/RightNav.vue
@@ -1,0 +1,42 @@
+<template>
+  <v-navigation-drawer rail location="right" permanent>
+    <v-list>
+      <v-list-item
+        v-for="item in items"
+        :key="item.value"
+        :active="item.value === modelValue"
+        @click="selectItem(item)"
+        density="comfortable"
+      >
+        <template #prepend>
+          <v-icon>{{ item.icon }}</v-icon>
+        </template>
+      </v-list-item>
+    </v-list>
+  </v-navigation-drawer>
+</template>
+
+<script setup>
+import { defineProps, defineEmits } from 'vue'
+
+const props = defineProps({
+  modelValue: { type: String, default: 'panel' }
+})
+
+const emit = defineEmits(['update:modelValue', 'open-settings'])
+
+const items = [
+  { value: 'panel', icon: 'mdi-view-dashboard' },
+  { value: 'nodes', icon: 'mdi-chip' },
+  { value: 'list', icon: 'mdi-format-list-bulleted' },
+  { value: 'settings', icon: 'mdi-cog' }
+]
+
+const selectItem = (item) => {
+  if (item.value === 'settings') {
+    emit('open-settings')
+  } else {
+    emit('update:modelValue', item.value)
+  }
+}
+</script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -9,23 +9,7 @@
       @refresh="fetchNodes"
     />
 
-<v-btn
-  icon
-  class="ma-2"
-  :style="{ position: 'fixed', top: '80px', left: drawer ? '240px' : '10px', zIndex: 1000 }"
-  @click="drawer = !drawer"
->
-  <v-icon>{{ drawer ? 'mdi-menu-open' : 'mdi-menu' }}</v-icon>
-</v-btn>
-
-<v-btn
-  icon
-  class="ma-2"
-  :style="{ position: 'fixed', top: '80px', right: '10px', zIndex: 1000 }"
-  @click="settingsOpen = true"
->
-  <v-icon>mdi-cog</v-icon>
-</v-btn>
+    <RightNav v-model="activeSection" @open-settings="settingsOpen = true" />
 
 <PanelSettings
   v-model="settingsOpen"
@@ -44,7 +28,13 @@
             <h2 class="text-h5 mb-4">{{ activeDashboard }}</h2>
           </v-col>
         </v-row>
-        <NodePanel :nodes="panelNodes" :per-row="perRow" @toggle="toggleNode" />
+        <NodePanel
+          v-if="activeSection === 'panel'"
+          :nodes="panelNodes"
+          :per-row="perRow"
+          @toggle="toggleNode"
+        />
+        <NodeList v-else-if="activeSection === 'list'" :nodes="nodes" />
       </v-container>
     </v-main>
   </v-app>
@@ -53,6 +43,8 @@
 <script setup>
 import NodeDrawer from '@/components/NodeDrawer.vue'
 import NodePanel from '@/components/NodePanel.vue'
+import NodeList from '@/components/NodeList.vue'
+import RightNav from '@/components/RightNav.vue'
 import PanelSettings from '@/components/PanelSettings.vue'
 import { ref, onMounted, watch } from 'vue'
 import api from '@/plugins/axios'
@@ -63,6 +55,7 @@ const dashboards = ref({ default: '', layouts: {} })
 const activeDashboard = ref('')
 const drawer = ref(false)
 const settingsOpen = ref(false)
+const activeSection = ref('panel')
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
 const selectedDashboard = ref('')
 
@@ -88,6 +81,14 @@ watch(activeDashboard, val => {
     panelNodes.value = ids
       .map(id => nodes.value.find(n => n.id === id))
       .filter(n => n)
+  }
+})
+
+watch(activeSection, val => {
+  if (val === 'nodes') {
+    drawer.value = true
+  } else if (drawer.value) {
+    drawer.value = false
   }
 })
 


### PR DESCRIPTION
## Summary
- create `RightNav` for quick actions on the right side
- add a simple `NodeList` component
- show different content in `DashboardView` depending on selected item

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68458f3b2ff8832ebf054469937c470c