### PR TITLE
UI drawer improvements

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -1,11 +1,11 @@
 <template>
   <v-navigation-drawer
     v-model="localOpen"
-    app
-    temporary
-
-  style="overflow-y:auto"
- main
+    absolute
+    location="left"
+    width="300"
+    class="node-drawer"
+    style="overflow-y:auto"
   >
     <v-list>
       <v-list-item>
@@ -113,5 +113,12 @@ const addNode = async () => {
   }
 }
 
-
 </script>
+
+<style scoped>
+.node-drawer {
+  left: 56px;
+  top: 0;
+  height: 100%;
+}
+</style>

--- a/frontend/src/components/NodeList.vue
+++ b/frontend/src/components/NodeList.vue
@@ -1,18 +1,27 @@
 <template>
   <v-container>
-    <v-list>
-      <v-list-item v-for="node in nodes" :key="node.id">
-        <v-list-item-content>
-          <v-list-item-title>{{ node.name }}</v-list-item-title>
-          <v-list-item-subtitle>{{ node.identifier }}</v-list-item-subtitle>
-        </v-list-item-content>
-      </v-list-item>
-    </v-list>
+    <v-data-table :headers="headers" :items="nodes" density="comfortable">
+      <template #item.state="{ item }">
+        <v-icon :color="item.state ? 'green' : 'red'">
+          {{ item.state ? 'mdi-check-circle' : 'mdi-close-circle' }}
+        </v-icon>
+      </template>
+    </v-data-table>
   </v-container>
 </template>
 
 <script setup>
 import { defineProps } from 'vue'
+
+const headers = [
+  { title: 'Nombre', value: 'name' },
+  { title: 'Identificador', value: 'identifier' },
+  { title: 'Ubicación', value: 'location' },
+  { title: 'Voltaje', value: 'voltage' },
+  { title: 'Corriente', value: 'current' },
+  { title: 'RSSI', value: 'rssi' },
+  { title: 'Estado', value: 'state' }
+]
 
 const props = defineProps({
   nodes: { type: Array, default: () => [] }

--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -1,8 +1,14 @@
 <template>
-  <v-dialog v-model="localOpen" max-width="400">
-    <v-card>
+  <v-navigation-drawer
+    v-model="localOpen"
+    absolute
+    location="left"
+    width="300"
+    class="settings-drawer"
+  >
+    <v-card flat>
       <v-card-title>Panel Settings</v-card-title>
-  <v-card-text>
+      <v-card-text>
         <v-slider
           v-model="localCols"
           :min="1"
@@ -39,7 +45,7 @@
         <v-btn text @click="localOpen = false">Cerrar</v-btn>
       </v-card-actions>
     </v-card>
-  </v-dialog>
+  </v-navigation-drawer>
 </template>
 
 <script setup>
@@ -89,3 +95,11 @@ const load = () => {
   }
 }
 </script>
+
+<style scoped>
+.settings-drawer {
+  left: 56px;
+  top: 0;
+  height: 100%;
+}
+</style>

--- a/frontend/src/components/RightNav.vue
+++ b/frontend/src/components/RightNav.vue
@@ -7,6 +7,7 @@
         :active="item.value === modelValue"
         @click="selectItem(item)"
         density="comfortable"
+        :title="item.title"
       >
         <template #prepend>
           <v-icon>{{ item.icon }}</v-icon>
@@ -26,10 +27,10 @@ const props = defineProps({
 const emit = defineEmits(['update:modelValue', 'open-settings'])
 
 const items = [
-  { value: 'panel', icon: 'mdi-view-dashboard' },
-  { value: 'nodes', icon: 'mdi-chip' },
-  { value: 'list', icon: 'mdi-format-list-bulleted' },
-  { value: 'settings', icon: 'mdi-cog' }
+  { value: 'panel', icon: 'mdi-view-dashboard', title: 'Dashboard' },
+  { value: 'nodes', icon: 'mdi-chip', title: 'Tus nodos' },
+  { value: 'list', icon: 'mdi-format-list-bulleted', title: 'Lista de nodos' },
+  { value: 'settings', icon: 'mdi-cog', title: 'Ajustes' }
 ]
 
 const selectItem = (item) => {


### PR DESCRIPTION
## Summary
- show tooltips in the sidebar icons
- display node list in a table
- convert node drawer to a compact docked panel
- open settings in a drawer instead of a dialog

## Testing
- `npm test` *(fails: could not read package.json)*
- `cd backend && npm test` *(fails: no test specified)*
- `cd ../frontend && npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac5d4aac832e809ae41fe896f825