### PR TITLE
Improve node drawer and navigation

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -2,7 +2,7 @@
   <v-navigation-drawer
     v-model="localOpen"
     absolute
-    location="left"
+    location="right"
     width="300"
     class="node-drawer"
     style="overflow-y:auto"
@@ -117,7 +117,7 @@ const addNode = async () => {
 
 <style scoped>
 .node-drawer {
-  left: 56px;
+  right: 56px;
   top: 0;
   height: 100%;
 }

--- a/frontend/src/components/RightNav.vue
+++ b/frontend/src/components/RightNav.vue
@@ -7,7 +7,7 @@
         :active="item.value === modelValue"
         @click="selectItem(item)"
         density="comfortable"
-        :title="item.title"
+        v-tooltip="{ text: item.title }"
       >
         <template #prepend>
           <v-icon>{{ item.icon }}</v-icon>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -25,7 +25,15 @@
       <v-container>
         <v-row>
           <v-col cols="12">
-            <h2 class="text-h5 mb-4">{{ activeDashboard }}</h2>
+            <v-tabs v-model="activeDashboard" class="mb-4">
+              <v-tab
+                v-for="(layout, name) in dashboards.layouts"
+                :key="name"
+                :value="name"
+              >
+                {{ name }}
+              </v-tab>
+            </v-tabs>
           </v-col>
         </v-row>
         <NodePanel


### PR DESCRIPTION
## Summary
- tweak NodeDrawer so it appears on the right
- expose dashboard tabs to quickly switch dashboards
- show tooltips on navigation icons

## Testing
- `npm test` within backend (fails: no test specified)
- `npm run build` within frontend (fails: vite not found)

------
https://chatgpt.com/codex/tasks/task_e_6845b28dc354832e957eb1d394c916c8