### PR TITLE
Move RightNav to the left

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -117,7 +117,7 @@ const addNode = async () => {
 
 <style scoped>
 .node-drawer {
-  right: 56px;
+  right: 0;
   top: 0;
   height: 100%;
 }

--- a/frontend/src/components/RightNav.vue
+++ b/frontend/src/components/RightNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-navigation-drawer rail location="right" permanent>
+  <v-navigation-drawer rail location="left" permanent>
     <v-list>
       <v-list-item
         v-for="item in items"


### PR DESCRIPTION
## Summary
- move RightNav drawer to the left
- remove unused right offset in NodeDrawer

## Testing
- `npm run build` in frontend
- `npm test` in backend *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845d22b81f0832eb82103a88003f6b6