### PR TITLE
Fix node drawer layout

### DIFF
--- a/frontend/src/components/NodeDrawer.vue
+++ b/frontend/src/components/NodeDrawer.vue
@@ -2,7 +2,7 @@
   <v-navigation-drawer
     v-model="localOpen"
     absolute
-    location="right"
+    location="left"
     width="300"
     class="node-drawer"
     style="overflow-y:auto"
@@ -117,7 +117,7 @@ const addNode = async () => {
 
 <style scoped>
 .node-drawer {
-  right: 0;
+  left: 56px;
   top: 0;
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- show node drawer from left side just like panel settings

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ad50ff84832ea51b08707ad33946