### PR TITLE
Add half-circle current gauge to dashboard

### DIFF
--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -15,24 +15,29 @@
             </v-btn>
           </v-card-title>
           <v-divider></v-divider>
-          <v-row class="pa-2 text-center" density="compact">
-            <v-col cols="4">
-              <v-icon color="primary">mdi-signal</v-icon>
-              <div class="text-caption">RSSI</div>
-              <div class="text-body-2">{{ node.rssi ?? 'N/A' }}</div>
-            </v-col>
-            <v-col cols="4">
-              <v-icon color="primary">mdi-flash</v-icon>
-              <div class="text-caption">Voltaje</div>
-              <div class="text-body-2">{{ node.voltage ?? 'N/A' }} V</div>
-            </v-col>
-            <v-col cols="4">
-              <v-icon color="primary">mdi-current-ac</v-icon>
-              <div class="text-caption">Corriente</div>
-              <div class="text-body-2">{{ node.current ?? 'N/A' }} A</div>
-            </v-col>
-          </v-row>
-        </v-card>
+        <v-row class="pa-2 text-center" density="compact">
+          <v-col cols="4">
+            <v-icon color="primary">mdi-signal</v-icon>
+            <div class="text-caption">RSSI</div>
+            <div class="text-body-2">{{ node.rssi ?? 'N/A' }}</div>
+          </v-col>
+          <v-col cols="4">
+            <v-icon color="primary">mdi-flash</v-icon>
+            <div class="text-caption">Voltaje</div>
+            <div class="text-body-2">{{ node.voltage ?? 'N/A' }} V</div>
+          </v-col>
+          <v-col cols="4">
+            <v-icon color="primary">mdi-current-ac</v-icon>
+            <div class="text-caption">Corriente</div>
+            <div class="text-body-2">{{ node.current ?? 'N/A' }} A</div>
+          </v-col>
+        </v-row>
+        <v-row class="pb-4">
+          <v-col cols="12">
+            <SemiGauge :value="Number(node.current) || 0" :max="10" />
+          </v-col>
+        </v-row>
+      </v-card>
       </v-col>
     </v-row>
   </v-container>
@@ -40,6 +45,7 @@
 
 <script setup>
 import { defineProps, defineEmits, computed } from 'vue'
+import SemiGauge from '@/components/SemiGauge.vue'
 
 const props = defineProps({
   nodes: { type: Array, default: () => [] },

--- a/frontend/src/components/SemiGauge.vue
+++ b/frontend/src/components/SemiGauge.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="semi-gauge">
+    <svg viewBox="0 0 100 50" class="gauge-svg">
+      <path d="M10 50 A40 40 0 0 1 90 50" class="gauge-bg" />
+      <line x1="50" y1="50" x2="50" y2="15" class="gauge-needle" :transform="`rotate(${rotation} 50 50)`" />
+    </svg>
+    <div class="gauge-label">{{ value }} A</div>
+  </div>
+</template>
+
+<script setup>
+import { computed, defineProps } from 'vue'
+
+const props = defineProps({
+  value: { type: Number, default: 0 },
+  max: { type: Number, default: 10 }
+})
+
+const rotation = computed(() => (props.value / props.max) * 180 - 90)
+</script>
+
+<style scoped>
+.semi-gauge {
+  width: 100%;
+  text-align: center;
+}
+.gauge-svg {
+  width: 100%;
+  max-width: 120px;
+  display: block;
+  margin: auto;
+}
+.gauge-bg {
+  fill: none;
+  stroke: #ccc;
+  stroke-width: 5;
+}
+.gauge-needle {
+  stroke: #f44336;
+  stroke-width: 2;
+  transform-origin: 50px 50px;
+}
+.gauge-label {
+  margin-top: -5px;
+  font-size: 0.8rem;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a `SemiGauge` component for a simple half circle gauge with a needle
- display the gauge in each node card on the dashboard

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68470d993768832e8ffd29aa9354d2b1