### PR TITLE
Center gauge alignment

### DIFF
--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -32,8 +32,8 @@
             <div class="text-body-2">{{ node.current ?? 'N/A' }} A</div>
           </v-col>
         </v-row>
-        <v-row class="pb-4">
-          <v-col cols="12">
+        <v-row class="pb-0 justify-center">
+          <v-col cols="12" class="d-flex justify-center">
             <VueSpeedometer
               :value="Number(node.current) || 0"
               :min-value="0"


### PR DESCRIPTION
## Summary
- center the speedometer gauge in `NodePanel.vue`
- remove extra bottom padding

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68471f5c3c10832e8af1879ef1cc2109