### PR TITLE
Allow Enter key to submit login

### DIFF
--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -10,6 +10,7 @@
         <v-text-field
           :label="t('username')"
           v-model="username"
+          @keyup.enter="doLogin"
           :error-messages="errors.username"
         />
         <v-text-field
@@ -18,6 +19,7 @@
           :type="showPassword ? 'text' : 'password'"
           :append-inner-icon="showPassword ? 'mdi-eye-off' : 'mdi-eye'"
           @click:append-inner="showPassword = !showPassword"
+          @keyup.enter="doLogin"
           :error-messages="errors.password"
         />
 


### PR DESCRIPTION
## Summary
- make login form submit when pressing **Enter** on username or password fields

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848372930d0832e8c7ce59418679b54