### PR TITLE
Fix map view persistence logic

### DIFF
--- a/frontend/src/components/NodeMap.vue
+++ b/frontend/src/components/NodeMap.vue
@@ -53,7 +53,8 @@ const nodesWithCoords = computed(() =>
     .filter(Boolean)
 )
 
-const savedView = JSON.parse(localStorage.getItem('mapView') || '{}')
+let savedView = {}
+try { savedView = JSON.parse(localStorage.getItem('mapView') || '{}') } catch {}
 const center = ref(savedView.center || [0, 0])
 const zoom = ref(savedView.zoom || 5)
 let hasSavedView = Boolean(savedView.center)
@@ -106,11 +107,13 @@ onMounted(() => {
   fetchZones()
   drawControl = new L.Control.Draw({ edit: { featureGroup: zoneLayer } })
   map.addControl(drawControl)
-  map.on('moveend zoomend', () => {
+  const saveView = () => {
     const view = { center: [map.getCenter().lat, map.getCenter().lng], zoom: map.getZoom() }
     localStorage.setItem('mapView', JSON.stringify(view))
     hasSavedView = true
-  })
+  }
+  map.on('moveend', saveView)
+  map.on('zoomend', saveView)
   map.on(L.Draw.Event.CREATED, async e => {
     if (e.layerType === 'polygon') {
       const latlngs = e.layer.getLatLngs()[0].map(ll => [ll.lat, ll.lng])


### PR DESCRIPTION
## Summary
- make mapView load robust to malformed JSON
- factor map view saving into reusable `saveView` handler

## Testing
- `npm test` (fails: missing script)
- `npm test` in backend (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68497d22b0b4832e8008fcd6269091ce