### PR TITLE
Add WhatsApp alert support and phone field

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+TWILIO_SID=your_twilio_sid
+TWILIO_TOKEN=your_twilio_token
+TWILIO_FROM=whatsapp:+1234567890

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "express": "^5.1.0",
+        "geolib": "^3.3.4",
         "influx": "^5.10.0",
         "jsonwebtoken": "^9.0.2",
         "mqtt": "^5.13.0",
@@ -993,6 +994,12 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ==",
+      "license": "MIT"
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,12 +14,13 @@
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "geolib": "^3.3.4",
     "influx": "^5.10.0",
     "jsonwebtoken": "^9.0.2",
     "mqtt": "^5.13.0",
     "nodemailer": "^7.0.3",
     "sqlite3": "^5.1.7",
-    "ws": "^8.18.2",
-    "twilio": "^5.7.0"
+    "twilio": "^5.7.0",
+    "ws": "^8.18.2"
   }
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -9,8 +9,8 @@ const api = axios.create({
 export const login = (username, password) =>
   api.post('/login', { username, password })
 
-export const register = (username, email, password) =>
-  api.post('/register', { username, email, password })
+export const register = (username, email, password, phone) =>
+  api.post('/register', { username, email, password, phone })
 
 export const getNodes = (token) =>
   api.get('/nodes', {

--- a/frontend/src/views/Register.vue
+++ b/frontend/src/views/Register.vue
@@ -18,6 +18,11 @@
           :error-messages="errors.email"
         />
         <v-text-field
+          :label="t('phone')"
+          v-model="phone"
+          :error-messages="errors.phone"
+        />
+        <v-text-field
           :label="t('password')"
           v-model="password"
           :type="showPassword ? 'text' : 'password'"
@@ -66,6 +71,7 @@ const lang = inject('lang', ref('es'))
 
 const username = ref('')
 const email = ref('')
+const phone = ref('')
 const password = ref('')
 const confirmPassword = ref('')
 const error = ref('')
@@ -73,7 +79,7 @@ const success = ref(false)
 const loading = ref(false)
 const showPassword = ref(false)
 
-const errors = ref({ username: '', email: '', password: '', confirm: '' })
+const errors = ref({ username: '', email: '', phone: '', password: '', confirm: '' })
 
 const t = (key) => {
   const texts = {
@@ -81,6 +87,7 @@ const t = (key) => {
       title: 'Registro de usuario',
       username: 'Usuario',
       email: 'Correo electrónico',
+      phone: 'Teléfono',
       password: 'Contraseña',
       confirm: 'Confirmar contraseña',
       register: 'Registrarse',
@@ -94,6 +101,7 @@ const t = (key) => {
       title: 'User Registration',
       username: 'Username',
       email: 'Email',
+      phone: 'Phone',
       password: 'Password',
       confirm: 'Confirm password',
       register: 'Register',
@@ -110,10 +118,11 @@ const t = (key) => {
 const registerUser = async () => {
   error.value = ''
   success.value = false
-  errors.value = { username: '', email: '', password: '', confirm: '' }
+  errors.value = { username: '', email: '', phone: '', password: '', confirm: '' }
 
   if (!username.value) errors.value.username = t('required')
   if (!email.value) errors.value.email = t('required')
+  if (!phone.value) errors.value.phone = t('required')
   if (!password.value) errors.value.password = t('required')
   if (!confirmPassword.value) errors.value.confirm = t('required')
   if (password.value && confirmPassword.value && password.value !== confirmPassword.value) {
@@ -124,10 +133,11 @@ const registerUser = async () => {
 
   loading.value = true
   try {
-    await register(username.value, email.value, password.value)
+    await register(username.value, email.value, password.value, phone.value)
     success.value = true
     username.value = ''
     email.value = ''
+    phone.value = ''
     password.value = ''
     confirmPassword.value = ''
   } catch (err) {


### PR DESCRIPTION
## Summary
- allow Twilio config via `.env.example`
- add phone column to users table and extend registration
- send WhatsApp alerts using Twilio with env fallback
- trigger alerts when nodes move outside zones for 3+ points and when they return
- include phone input in register form and API

## Testing
- `npm test` (fails: Error: no test specified)
- `npm test` in frontend (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68498f48259c832ead62b1f6b8e121ef