### PR TITLE
Fix zone routes by running correct backend entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Lora Platform
+
+This project contains a frontend built with Vue 3 and a backend written in Node.js.
+
+## Backend
+
+Make sure to run the backend using the provided start script so that the correct entry point (`index.js`) is used:
+
+```bash
+cd backend
+npm install
+npm start
+```
+
+The backend exposes routes such as `/zones` which are required by the frontend.
+
+## Frontend
+
+The frontend can be started with Vite:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+By default, the frontend Axios instance points to `http://3.66.72.52:3010`. Adjust this in `src/plugins/axios.js` if your backend runs elsewhere.

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add start script to backend so `npm start` runs `index.js`
- document how to start backend and frontend in new README

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684996104424832e8f2d7c7a4905fa87