### PR TITLE
Move Twilio config into backend code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,0 @@
-TWILIO_SID=your_twilio_sid
-TWILIO_TOKEN=your_twilio_token
-TWILIO_FROM=whatsapp:+1234567890

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,6 +10,12 @@ const nodemailer = require('nodemailer');
 const twilio = require('twilio');
 const geolib = require('geolib');
 
+// Twilio credentials are now configured directly in code instead of
+// relying on environment variables.
+const TWILIO_SID = 'your_twilio_sid';
+const TWILIO_TOKEN = 'your_twilio_token';
+const TWILIO_FROM = 'whatsapp:+1234567890';
+
 const transporter = nodemailer.createTransport({
   service: 'Gmail',
   auth: {
@@ -69,9 +75,10 @@ function sendAlerts(userId, message) {
       }).catch(e => console.error('❌ Telegram:', e));
     }
 
-    const sid = process.env.TWILIO_SID || (row && row.whatsapp_sid);
-    const token = process.env.TWILIO_TOKEN || (row && row.whatsapp_token);
-    const from = process.env.TWILIO_FROM || (row && row.whatsapp_from);
+    // Use the hardcoded Twilio credentials defined at the top of the file.
+    const sid = TWILIO_SID || (row && row.whatsapp_sid);
+    const token = TWILIO_TOKEN || (row && row.whatsapp_token);
+    const from = TWILIO_FROM || (row && row.whatsapp_from);
 
     if (sid && token && from) {
       db.get('SELECT phone FROM users WHERE id = ?', [userId], (pErr, uRow) => {


### PR DESCRIPTION
## Summary
- configure Twilio credentials directly in `index.js`
- remove old `.env.example`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68499fbecf00832ead4da5142e215f50