### PR TITLE
Add node simulator and location updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ By default the frontend assumes the backend is reachable at `http://3.66.72.52:3
 ## Additional notes
 
 Running the project will create a local `lora.db` SQLite database.  The `docs/overview.md` file contains a short summary of the architecture.
+
+## Node simulation
+
+The `scripts/simulate_node.js` file can publish fake sensor data to the MQTT
+broker every 30&nbsp;seconds.  It sends voltage, current, RSSI and a `location`
+string (`"lat,lng"`).  By default the script uses a small square as zone but you
+can provide your own polygon via the `ZONE_POLYGON` environment variable (path
+to a JSON file containing an array of `[lat, lng]` pairs).
+
+Example usage:
+
+```bash
+node scripts/simulate_node.js \
+  MQTT_TOPIC="nodos/demo/data" \
+  MQTT_BROKER="mqtt://localhost:1883" \
+  ZONE_POLYGON=./myZone.json
+```
+
+The simulated node mostly stays inside the zone but occasionally leaves it for a
+couple of minutes so that alert notifications can be tested.

--- a/backend/index.js
+++ b/backend/index.js
@@ -228,11 +228,11 @@ mqttClient.on('message', (topic, message) => {
     const data = JSON.parse(message.toString());
     const parts = topic.split('/');
     const identifier = parts[1];
-    const { voltage, current, rssi } = data;
+    const { voltage, current, rssi, location } = data;
 
     db.run(
-      `UPDATE nodes SET voltage = ?, current = ?, rssi = ? WHERE identifier = ?`,
-      [voltage, current, rssi, identifier],
+      `UPDATE nodes SET voltage = ?, current = ?, rssi = ?, location = COALESCE(?, location) WHERE identifier = ?`,
+      [voltage, current, rssi, location, identifier],
       (err) => {
         if (err) {
           console.error('❌ Error al actualizar nodo:', err);
@@ -247,7 +247,8 @@ mqttClient.on('message', (topic, message) => {
                 identifier,
                 voltage,
                 current,
-                rssi
+                rssi,
+                location
               }));
             }
           });

--- a/scripts/simulate_node.js
+++ b/scripts/simulate_node.js
@@ -1,0 +1,91 @@
+const mqtt = require('mqtt');
+const fs = require('fs');
+
+const brokerUrl = process.env.MQTT_BROKER || 'mqtt://localhost:1883';
+const topic = process.env.MQTT_TOPIC || 'nodos/demo/data';
+const polygonFile = process.env.ZONE_POLYGON || null;
+const identifier = topic.split('/')[1];
+
+let polygon = [
+  [37.7749, -122.4194],
+  [37.7758, -122.4194],
+  [37.7758, -122.4178],
+  [37.7749, -122.4178]
+];
+if (polygonFile) {
+  try {
+    const data = fs.readFileSync(polygonFile, 'utf8');
+    polygon = JSON.parse(data);
+  } catch (e) {
+    console.error('Failed to load polygon from', polygonFile, e.message);
+  }
+}
+
+function pointInPolygon(point, vs) {
+  const x = point[0], y = point[1];
+  let inside = false;
+  for (let i = 0, j = vs.length - 1; i < vs.length; j = i++) {
+    const xi = vs[i][0], yi = vs[i][1];
+    const xj = vs[j][0], yj = vs[j][1];
+    const intersect = ((yi > y) !== (yj > y)) &&
+      (x < (xj - xi) * (y - yi) / (yj - yi) + xi);
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+function bounds(poly) {
+  const lats = poly.map(p => p[0]);
+  const lngs = poly.map(p => p[1]);
+  return {
+    minLat: Math.min(...lats),
+    maxLat: Math.max(...lats),
+    minLng: Math.min(...lngs),
+    maxLng: Math.max(...lngs)
+  };
+}
+
+function randomIn(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
+function randomPointInside(poly) {
+  const b = bounds(poly);
+  for (let i = 0; i < 100; i++) {
+    const p = [randomIn(b.minLat, b.maxLat), randomIn(b.minLng, b.maxLng)];
+    if (pointInPolygon(p, poly)) return p;
+  }
+  return [b.minLat, b.minLng];
+}
+
+function randomPointOutside(poly) {
+  const b = bounds(poly);
+  const latSpan = b.maxLat - b.minLat;
+  const lngSpan = b.maxLng - b.minLng;
+  for (let i = 0; i < 100; i++) {
+    const p = [randomIn(b.minLat - latSpan, b.maxLat + latSpan),
+               randomIn(b.minLng - lngSpan, b.maxLng + lngSpan)];
+    if (!pointInPolygon(p, poly)) return p;
+  }
+  return [b.maxLat + latSpan, b.maxLng + lngSpan];
+}
+
+let outsideSteps = 0;
+const client = mqtt.connect(brokerUrl);
+client.on('connect', () => {
+  console.log('Connected to', brokerUrl);
+  send();
+  setInterval(send, 30000);
+});
+
+function send() {
+  const voltage = randomIn(218, 235).toFixed(2);
+  const current = randomIn(1, 5).toFixed(2);
+  const rssi = (randomIn(-100, -50)).toFixed(0);
+  if (outsideSteps > 0) outsideSteps--; else if (Math.random() < 0.1) outsideSteps = 4;
+  const coords = outsideSteps > 0 ? randomPointOutside(polygon) : randomPointInside(polygon);
+  const location = `${coords[0].toFixed(6)},${coords[1].toFixed(6)}`;
+  const payload = { voltage, current, rssi, location };
+  client.publish(topic, JSON.stringify(payload));
+  console.log('Published', identifier, payload);
+}


### PR DESCRIPTION
## Summary
- update MQTT handler to store `location` when provided and broadcast it via WebSockets
- add `scripts/simulate_node.js` to publish fake node data every 30 seconds
- document how to use the simulator

## Testing
- `node -c scripts/simulate_node.js`
- `node -c backend/index.js`


------
https://chatgpt.com/codex/tasks/task_e_684a744508b0832eb4d00e153f611da1