### PR TITLE
Update settings layout

### DIFF
--- a/frontend/src/components/NodeSettings.vue
+++ b/frontend/src/components/NodeSettings.vue
@@ -1,0 +1,76 @@
+<template>
+  <v-card>
+    <v-toolbar density="compact" flat>
+      <v-toolbar-title>Tus Nodos</v-toolbar-title>
+      <v-spacer />
+      <v-btn icon color="primary" @click="dialog = true">
+        <v-icon>mdi-plus</v-icon>
+      </v-btn>
+    </v-toolbar>
+    <v-divider></v-divider>
+    <v-list density="compact">
+      <v-list-item v-for="node in nodes" :key="node.id" class="px-2">
+        <v-checkbox
+          :label="node.name"
+          hide-details
+          density="compact"
+          color="primary"
+          :model-value="panelNodes.some(n => n.id === node.id)"
+          @update:model-value="val => val ? addNodeToPanel(node) : removeNodeFromPanel(node)"
+        />
+      </v-list-item>
+    </v-list>
+
+    <v-dialog v-model="dialog" max-width="500">
+      <v-card>
+        <v-card-title>Añadir Nodo</v-card-title>
+        <v-card-text>
+          <v-text-field v-model="name" label="Nombre"></v-text-field>
+          <v-text-field v-model="location" label="Ubicación"></v-text-field>
+          <v-text-field v-model="identifier" label="Identificador MQTT"></v-text-field>
+        </v-card-text>
+        <v-card-actions>
+          <v-btn color="primary" @click="addNode">Guardar</v-btn>
+          <v-btn text @click="dialog = false">Cancelar</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-card>
+</template>
+
+<script setup>
+import { ref, defineProps, defineEmits } from 'vue'
+import api from '@/plugins/axios'
+
+const props = defineProps({
+  nodes: { type: Array, default: () => [] },
+  panelNodes: { type: Array, default: () => [] }
+})
+
+const emit = defineEmits(['add', 'remove', 'refresh'])
+
+const dialog = ref(false)
+const name = ref('')
+const location = ref('')
+const identifier = ref('')
+
+const addNodeToPanel = (node) => emit('add', node)
+const removeNodeFromPanel = (node) => emit('remove', node)
+
+const addNode = async () => {
+  try {
+    await api.post('/nodes/create', {
+      name: name.value,
+      location: location.value,
+      identifier: identifier.value
+    })
+    dialog.value = false
+    name.value = ''
+    location.value = ''
+    identifier.value = ''
+    emit('refresh')
+  } catch (err) {
+    console.error('❌ Error al crear nodo:', err)
+  }
+}
+</script>

--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -3,72 +3,98 @@
     v-model="localOpen"
     absolute
     location="left"
-    width="300"
+    width="200"
     class="settings-drawer"
   >
     <v-card flat>
-      <v-card-title>Settings</v-card-title>
-      <v-tabs v-model="activeTab" density="comfortable">
-        <v-tab value="dashboard">Dashboard</v-tab>
-        <v-tab value="general">General</v-tab>
-      </v-tabs>
-      <v-window v-model="activeTab" class="mt-2">
-        <v-window-item value="dashboard">
-          <v-card-text>
-            <v-slider
-              v-model="localCols"
-              :min="1"
-              :max="4"
-              step="1"
-              thumb-label
-              label="Nodos por fila"
-            ></v-slider>
+      <v-card-title>Ajustes</v-card-title>
+      <v-divider></v-divider>
+      <v-list density="comfortable">
+        <v-list-item
+          v-for="item in items"
+          :key="item.value"
+          :active="activeItem === item.value"
+          @click="activeItem = item.value"
+        >
+          <v-list-item-title>{{ item.title }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-card>
+  </v-navigation-drawer>
 
-            <v-text-field
-              v-model="dashboardName"
-              label="Nombre del dashboard"
-              class="mt-4"
-            ></v-text-field>
-            <v-btn color="primary" class="mt-2" @click="save">Guardar actual</v-btn>
+  <div v-if="localOpen" class="settings-content">
+    <v-card flat class="pa-4">
+      <template v-if="activeItem === 'dashboard'">
+        <v-slider
+          v-model="localCols"
+          :min="1"
+          :max="4"
+          step="1"
+          thumb-label
+          label="Nodos por fila"
+        ></v-slider>
 
-            <v-select
-              v-model="selectedDash"
-              :items="props.dashboards"
-              label="Dashboards guardados"
-              class="mt-4"
-            ></v-select>
-            <v-btn class="mt-2" @click="load">Cargar</v-btn>
+        <v-text-field
+          v-model="dashboardName"
+          label="Nombre del dashboard"
+          class="mt-4"
+        ></v-text-field>
+        <v-btn color="primary" class="mt-2" @click="save">Guardar actual</v-btn>
 
-            <v-select
-              v-model="defaultDashLocal"
-              :items="props.dashboards"
-              label="Dashboard por defecto"
-              class="mt-4"
-            ></v-select>
-          </v-card-text>
-        </v-window-item>
-        <v-window-item value="general">
-          <v-card-text>
-            Ajustes generales próximamente...
-          </v-card-text>
-        </v-window-item>
-      </v-window>
-      <v-card-actions>
+        <v-select
+          v-model="selectedDash"
+          :items="props.dashboards"
+          label="Dashboards guardados"
+          class="mt-4"
+        ></v-select>
+        <v-btn class="mt-2" @click="load">Cargar</v-btn>
+
+        <v-select
+          v-model="defaultDashLocal"
+          :items="props.dashboards"
+          label="Dashboard por defecto"
+          class="mt-4"
+        ></v-select>
+      </template>
+
+      <template v-else-if="activeItem === 'general'">
+        Ajustes generales próximamente...
+      </template>
+
+      <template v-else-if="activeItem === 'alerts'">
+        <AlertSettings />
+      </template>
+
+      <template v-else-if="activeItem === 'nodes'">
+        <NodeSettings
+          :nodes="props.nodes"
+          :panel-nodes="props.panelNodes"
+          @add="emit('add-node', $event)"
+          @remove="emit('remove-node', $event)"
+          @refresh="emit('refresh-nodes')"
+        />
+      </template>
+
+      <v-card-actions class="mt-4">
         <v-spacer></v-spacer>
         <v-btn text @click="localOpen = false">Cerrar</v-btn>
       </v-card-actions>
     </v-card>
-  </v-navigation-drawer>
+  </div>
 </template>
 
 <script setup>
 import { ref, watch, defineProps, defineEmits } from 'vue'
+import AlertSettings from './AlertSettings.vue'
+import NodeSettings from './NodeSettings.vue'
 
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
   cols: { type: Number, default: 3 },
   dashboards: { type: Array, default: () => [] },
-  defaultDash: { type: String, default: '' }
+  defaultDash: { type: String, default: '' },
+  nodes: { type: Array, default: () => [] },
+  panelNodes: { type: Array, default: () => [] }
 })
 
 const emit = defineEmits([
@@ -76,7 +102,10 @@ const emit = defineEmits([
   'update:cols',
   'save-dashboard',
   'load-dashboard',
-  'update:defaultDash'
+  'update:defaultDash',
+  'add-node',
+  'remove-node',
+  'refresh-nodes'
 ])
 
 const localOpen = ref(props.modelValue)
@@ -84,7 +113,13 @@ const localCols = ref(props.cols)
 const dashboardName = ref('')
 const selectedDash = ref(props.defaultDash)
 const defaultDashLocal = ref(props.defaultDash)
-const activeTab = ref('dashboard')
+const activeItem = ref('dashboard')
+const items = [
+  { value: 'general', title: 'General' },
+  { value: 'dashboard', title: 'Dashboard' },
+  { value: 'alerts', title: 'Alertas' },
+  { value: 'nodes', title: 'Nodos' }
+]
 
 watch(() => props.modelValue, v => (localOpen.value = v))
 watch(() => props.cols, v => (localCols.value = v))
@@ -115,5 +150,14 @@ const load = () => {
   left: 56px;
   top: 0;
   height: 100%;
+}
+.settings-content {
+  position: fixed;
+  left: 256px;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  overflow-y: auto;
+  background: white;
 }
 </style>

--- a/frontend/src/components/RightNav.vue
+++ b/frontend/src/components/RightNav.vue
@@ -31,7 +31,6 @@ const items = [
   { value: 'nodes', icon: 'mdi-chip', title: 'Tus nodos' },
   { value: 'list', icon: 'mdi-format-list-bulleted', title: 'Lista de nodos' },
   { value: 'map', icon: 'mdi-map', title: 'Mapa' },
-  { value: 'alerts', icon: 'mdi-bell', title: 'Alertas' },
   { value: 'settings', icon: 'mdi-cog', title: 'Ajustes' }
 ]
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -17,10 +17,15 @@
   :cols="perRow"
   :dashboards="Object.keys(dashboards.layouts)"
   :default-dash="dashboards.default"
+  :nodes="nodes"
+  :panel-nodes="panelNodes"
   @update:cols="perRow = $event"
   @save-dashboard="saveDashboard"
   @load-dashboard="loadDashboard"
   @update:defaultDash="setDefaultDashboard"
+  @add-node="addToPanel"
+  @remove-node="removeFromPanel"
+  @refresh-nodes="fetchNodes"
 />
     <v-main>
       <v-container>
@@ -45,7 +50,6 @@
         />
         <NodeList v-else-if="activeSection === 'list'" :nodes="nodes" />
         <NodeMap v-else-if="activeSection === 'map'" :nodes="nodes" />
-        <AlertSettings v-else-if="activeSection === 'alerts'" />
       </v-container>
     </v-main>
   </v-app>
@@ -58,7 +62,6 @@ import NodeList from '@/components/NodeList.vue'
 import NodeMap from '@/components/NodeMap.vue'
 import RightNav from '@/components/RightNav.vue'
 import PanelSettings from '@/components/PanelSettings.vue'
-import AlertSettings from '@/components/AlertSettings.vue'
 import { ref, onMounted, watch } from 'vue'
 import api from '@/plugins/axios'
 


### PR DESCRIPTION
## Summary
- replace settings tabs with a list-based menu
- move alerts to the settings panel and add node settings panel
- remove alerts from navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ae30880a0832ea9cacab45fc2118d