### PR TITLE
Fix settings overlay with z-index

### DIFF
--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -150,6 +150,7 @@ const load = () => {
   left: 56px;
   top: 0;
   height: 100%;
+  z-index: 1100;
 }
 .settings-content {
   position: fixed;
@@ -159,5 +160,6 @@ const load = () => {
   bottom: 0;
   overflow-y: auto;
   background: white;
+  z-index: 1100;
 }
 </style>


### PR DESCRIPTION
## Summary
- raise `PanelSettings` drawer/content above map with `z-index: 1100`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ae767f704832e81cf1203c4a7623d