### PR TITLE
Maintain persistent sidebar navigation

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -41,6 +41,8 @@
       </v-menu>
     </v-app-bar>
 
+    <RightNav v-model="activeSection" @open-settings="goSettings" />
+
     <v-main>
       <router-view :lang="selectedLang" />
     </v-main>
@@ -48,8 +50,9 @@
 </template>
 
 <script setup>
-import { ref, provide, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
+import { ref, provide, onMounted, watch } from 'vue'
+import { useRouter, useRoute } from 'vue-router'
+import RightNav from '@/components/RightNav.vue'
 
 const selectedLang = ref('es')
 provide('lang', selectedLang)
@@ -57,6 +60,30 @@ provide('lang', selectedLang)
 const username = ref('')
 const loggedIn = ref(false)
 const router = useRouter()
+const route = useRoute()
+
+const activeSection = ref('panel')
+provide('activeSection', activeSection)
+
+watch(activeSection, val => {
+  if (val === 'settings') {
+    if (route.path !== '/settings') router.push('/settings')
+  } else {
+    if (route.path !== '/dashboard') router.push('/dashboard')
+  }
+})
+
+watch(
+  () => route.path,
+  path => {
+    if (path === '/settings') {
+      activeSection.value = 'settings'
+    } else if (path === '/dashboard' && activeSection.value === 'settings') {
+      activeSection.value = 'panel'
+    }
+  },
+  { immediate: true }
+)
 
 const updateAuth = () => {
   username.value = localStorage.getItem('username') || ''
@@ -78,5 +105,9 @@ const logout = () => {
   updateAuth()
   window.dispatchEvent(new Event('auth-changed'))
   router.push('/login')
+}
+
+const goSettings = () => {
+  activeSection.value = 'settings'
 }
 </script>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,6 +1,5 @@
 <template>
   <v-app>
-  <RightNav v-model="activeSection" @open-settings="goToSettings" />
     <NodeDrawer
       v-model="drawer"
       :nodes="nodes"
@@ -43,8 +42,7 @@ import NodeDrawer from '@/components/NodeDrawer.vue'
 import NodePanel from '@/components/NodePanel.vue'
 import NodeList from '@/components/NodeList.vue'
 import NodeMap from '@/components/NodeMap.vue'
-import RightNav from '@/components/RightNav.vue'
-import { ref, onMounted, watch } from 'vue'
+import { ref, onMounted, watch, inject } from 'vue'
 import { useRouter } from 'vue-router'
 import api from '@/plugins/axios'
 
@@ -53,11 +51,10 @@ const panelNodes = ref([])
 const dashboards = ref({ default: '', layouts: {} })
 const activeDashboard = ref('')
 const drawer = ref(false)
-const activeSection = ref('panel')
+const activeSection = inject('activeSection', ref('panel'))
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
 const selectedDashboard = ref('')
 const router = useRouter()
-const goToSettings = () => router.push('/settings')
 
 watch(perRow, val => localStorage.setItem('perRow', val))
 let firstLoad = true

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,6 +1,5 @@
 <template>
   <v-app>
-    <RightNav model-value="settings" @open-settings="null" />
     <PanelSettings
       v-model="open"
       :cols="perRow"
@@ -21,7 +20,6 @@
 </template>
 
 <script setup>
-import RightNav from '@/components/RightNav.vue'
 import PanelSettings from '@/components/PanelSettings.vue'
 import { ref, onMounted, watch } from 'vue'
 import api from '@/plugins/axios'


### PR DESCRIPTION
## Summary
- move `RightNav` to `App.vue` so the sidebar stays visible across views
- manage active section globally and sync with the router
- adjust dashboard and settings pages to use the global sidebar

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bc0e5619c832ea1a1263d8f706f6d