### PR TITLE
Implement settings sidebar with subroutes

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -8,6 +8,14 @@ import Recover from '../views/Recover.vue'
 import ResetPassword from '../views/ResetPassword.vue'
 import ProfileView from '../views/ProfileView.vue'
 import SettingsView from '../views/SettingsView.vue'
+import GeneralSettings from '../views/settings/GeneralSettings.vue'
+import DashboardSettings from '../views/settings/DashboardSettings.vue'
+import GroupsSettings from '../views/settings/GroupsSettings.vue'
+import NodesSettings from '../views/settings/NodesSettings.vue'
+import GatewaySettings from '../views/settings/GatewaySettings.vue'
+import AlarmsSettings from '../views/settings/AlarmsSettings.vue'
+import ProfilesSettings from '../views/settings/ProfilesSettings.vue'
+import SystemSettings from '../views/settings/SystemSettings.vue'
 
 const routes = [
 { path: '/', name: 'Landing', component: LandingView },
@@ -18,7 +26,21 @@ const routes = [
   { path: '/recover', component: Recover },
   { path: '/reset', component: ResetPassword },
   { path: '/profile', component: ProfileView },
-  { path: '/settings', component: SettingsView }
+  {
+    path: '/settings',
+    component: SettingsView,
+    children: [
+      { path: '', redirect: '/settings/general' },
+      { path: 'general', component: GeneralSettings },
+      { path: 'dashboard', component: DashboardSettings },
+      { path: 'groups', component: GroupsSettings },
+      { path: 'nodes', component: NodesSettings },
+      { path: 'gateway', component: GatewaySettings },
+      { path: 'alarms', component: AlarmsSettings },
+      { path: 'profiles', component: ProfilesSettings },
+      { path: 'system', component: SystemSettings }
+    ]
+  }
 ]
 
 const router = createRouter({

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -1,135 +1,37 @@
 <template>
-  <v-app>
-    <PanelSettings
-      v-model="open"
-      :cols="perRow"
-      :dashboards="Object.keys(dashboards.layouts)"
-      :default-dash="dashboards.default"
-      :nodes="nodes"
-      :panel-nodes="panelNodes"
-      full-page
-      @update:cols="perRow = $event"
-      @save-dashboard="saveDashboard"
-      @load-dashboard="loadDashboard"
-      @update:defaultDash="setDefaultDashboard"
-      @add-node="addToPanel"
-      @remove-node="removeFromPanel"
-      @refresh-nodes="fetchNodes"
-    />
-  </v-app>
+  <v-container fluid>
+    <v-row>
+      <v-col cols="12" md="3">
+        <v-card>
+          <v-list density="comfortable" nav>
+            <v-list-item
+              v-for="item in items"
+              :key="item.value"
+              :to="`/settings/${item.value}`"
+              :active="$route.path === `/settings/${item.value}`"
+              link
+            >
+              <v-list-item-title>{{ item.title }}</v-list-item-title>
+            </v-list-item>
+          </v-list>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="9">
+        <router-view />
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script setup>
-import PanelSettings from '@/components/PanelSettings.vue'
-import { ref, onMounted, watch } from 'vue'
-import api from '@/plugins/axios'
-
-const open = ref(true)
-const nodes = ref([])
-const panelNodes = ref([])
-const dashboards = ref({ default: '', layouts: {} })
-const activeDashboard = ref('')
-const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
-const selectedDashboard = ref('')
-
-watch(perRow, val => localStorage.setItem('perRow', val))
-let firstLoad = true
-
-watch(panelNodes, async val => {
-  if (!activeDashboard.value) return
-  try {
-    await api.post('/dashboards', {
-      name: activeDashboard.value,
-      layout: val.map(n => n.id),
-      isDefault: activeDashboard.value === dashboards.value.default
-    })
-  } catch (err) {
-    console.error('❌ Error al guardar dashboard:', err)
-  }
-}, { deep: true })
-
-watch(activeDashboard, val => {
-  if (dashboards.value.layouts[val]) {
-    const ids = dashboards.value.layouts[val]
-    panelNodes.value = ids
-      .map(id => nodes.value.find(n => n.id === id))
-      .filter(n => n)
-  }
-})
-
-const fetchNodes = async () => {
-  try {
-    const res = await api.get('/nodes')
-    nodes.value = res.data.map(n => ({ ...n, state: Boolean(n.state) }))
-    if (firstLoad && selectedDashboard.value) {
-      loadDashboard(selectedDashboard.value)
-      firstLoad = false
-    }
-  } catch (err) {
-    console.error('❌ Error al cargar nodos:', err)
-  }
-}
-
-const loadDashboards = async () => {
-  try {
-    const res = await api.get('/dashboards')
-    dashboards.value = { default: res.data.default, layouts: res.data.layouts }
-    activeDashboard.value = dashboards.value.default || Object.keys(dashboards.value.layouts)[0] || ''
-    selectedDashboard.value = dashboards.value.default
-    if (activeDashboard.value) {
-      const ids = dashboards.value.layouts[activeDashboard.value]
-      panelNodes.value = ids
-        .map(id => nodes.value.find(n => n.id === id))
-        .filter(n => n)
-    }
-  } catch (err) {
-    console.error('❌ Error al cargar dashboards:', err)
-  }
-}
-
-const addToPanel = (node) => {
-  if (!panelNodes.value.find(n => n.id === node.id)) {
-    panelNodes.value.push(node)
-  }
-}
-
-const removeFromPanel = (node) => {
-  panelNodes.value = panelNodes.value.filter(n => n.id !== node.id)
-}
-
-watch(panelNodes, () => {
-  if (activeDashboard.value) {
-    dashboards.value.layouts[activeDashboard.value] = panelNodes.value.map(n => n.id)
-  }
-}, { deep: true })
-
-const setDefaultDashboard = async (name) => {
-  dashboards.value.default = name
-  selectedDashboard.value = name
-  activeDashboard.value = name
-  try {
-    await api.post('/dashboards', {
-      name,
-      layout: dashboards.value.layouts[name] || [],
-      isDefault: true
-    })
-  } catch (err) {
-    console.error('❌ Error al actualizar dashboard por defecto:', err)
-  }
-}
-
-const saveDashboard = async (name) => {
-  dashboards.value.layouts[name] = panelNodes.value.map(n => n.id)
-  await setDefaultDashboard(name)
-}
-
-const loadDashboard = async (name) => {
-  const ids = dashboards.value.layouts[name] || []
-  panelNodes.value = ids.map(id => nodes.value.find(n => n.id === id)).filter(Boolean)
-  await setDefaultDashboard(name)
-}
-
-onMounted(() => {
-  fetchNodes().then(loadDashboards)
-})
+const items = [
+  { value: 'general', title: 'General' },
+  { value: 'dashboard', title: 'Dashboard' },
+  { value: 'groups', title: 'Groups' },
+  { value: 'nodes', title: 'Nodes' },
+  { value: 'gateway', title: 'Gateway' },
+  { value: 'alarms', title: 'Alarms' },
+  { value: 'profiles', title: 'Profiles' },
+  { value: 'system', title: 'System' }
+]
 </script>

--- a/frontend/src/views/settings/AlarmsSettings.vue
+++ b/frontend/src/views/settings/AlarmsSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>Alarms Settings</h2>
+    <p>Configure alarms here.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/DashboardSettings.vue
+++ b/frontend/src/views/settings/DashboardSettings.vue
@@ -1,0 +1,135 @@
+<template>
+  <v-app>
+    <PanelSettings
+      v-model="open"
+      :cols="perRow"
+      :dashboards="Object.keys(dashboards.layouts)"
+      :default-dash="dashboards.default"
+      :nodes="nodes"
+      :panel-nodes="panelNodes"
+      full-page
+      @update:cols="perRow = $event"
+      @save-dashboard="saveDashboard"
+      @load-dashboard="loadDashboard"
+      @update:defaultDash="setDefaultDashboard"
+      @add-node="addToPanel"
+      @remove-node="removeFromPanel"
+      @refresh-nodes="fetchNodes"
+    />
+  </v-app>
+</template>
+
+<script setup>
+import PanelSettings from '@/components/PanelSettings.vue'
+import { ref, onMounted, watch } from 'vue'
+import api from '@/plugins/axios'
+
+const open = ref(true)
+const nodes = ref([])
+const panelNodes = ref([])
+const dashboards = ref({ default: '', layouts: {} })
+const activeDashboard = ref('')
+const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
+const selectedDashboard = ref('')
+
+watch(perRow, val => localStorage.setItem('perRow', val))
+let firstLoad = true
+
+watch(panelNodes, async val => {
+  if (!activeDashboard.value) return
+  try {
+    await api.post('/dashboards', {
+      name: activeDashboard.value,
+      layout: val.map(n => n.id),
+      isDefault: activeDashboard.value === dashboards.value.default
+    })
+  } catch (err) {
+    console.error('❌ Error al guardar dashboard:', err)
+  }
+}, { deep: true })
+
+watch(activeDashboard, val => {
+  if (dashboards.value.layouts[val]) {
+    const ids = dashboards.value.layouts[val]
+    panelNodes.value = ids
+      .map(id => nodes.value.find(n => n.id === id))
+      .filter(n => n)
+  }
+})
+
+const fetchNodes = async () => {
+  try {
+    const res = await api.get('/nodes')
+    nodes.value = res.data.map(n => ({ ...n, state: Boolean(n.state) }))
+    if (firstLoad && selectedDashboard.value) {
+      loadDashboard(selectedDashboard.value)
+      firstLoad = false
+    }
+  } catch (err) {
+    console.error('❌ Error al cargar nodos:', err)
+  }
+}
+
+const loadDashboards = async () => {
+  try {
+    const res = await api.get('/dashboards')
+    dashboards.value = { default: res.data.default, layouts: res.data.layouts }
+    activeDashboard.value = dashboards.value.default || Object.keys(dashboards.value.layouts)[0] || ''
+    selectedDashboard.value = dashboards.value.default
+    if (activeDashboard.value) {
+      const ids = dashboards.value.layouts[activeDashboard.value]
+      panelNodes.value = ids
+        .map(id => nodes.value.find(n => n.id === id))
+        .filter(n => n)
+    }
+  } catch (err) {
+    console.error('❌ Error al cargar dashboards:', err)
+  }
+}
+
+const addToPanel = (node) => {
+  if (!panelNodes.value.find(n => n.id === node.id)) {
+    panelNodes.value.push(node)
+  }
+}
+
+const removeFromPanel = (node) => {
+  panelNodes.value = panelNodes.value.filter(n => n.id !== node.id)
+}
+
+watch(panelNodes, () => {
+  if (activeDashboard.value) {
+    dashboards.value.layouts[activeDashboard.value] = panelNodes.value.map(n => n.id)
+  }
+}, { deep: true })
+
+const setDefaultDashboard = async (name) => {
+  dashboards.value.default = name
+  selectedDashboard.value = name
+  activeDashboard.value = name
+  try {
+    await api.post('/dashboards', {
+      name,
+      layout: dashboards.value.layouts[name] || [],
+      isDefault: true
+    })
+  } catch (err) {
+    console.error('❌ Error al actualizar dashboard por defecto:', err)
+  }
+}
+
+const saveDashboard = async (name) => {
+  dashboards.value.layouts[name] = panelNodes.value.map(n => n.id)
+  await setDefaultDashboard(name)
+}
+
+const loadDashboard = async (name) => {
+  const ids = dashboards.value.layouts[name] || []
+  panelNodes.value = ids.map(id => nodes.value.find(n => n.id === id)).filter(Boolean)
+  await setDefaultDashboard(name)
+}
+
+onMounted(() => {
+  fetchNodes().then(loadDashboards)
+})
+</script>

--- a/frontend/src/views/settings/GatewaySettings.vue
+++ b/frontend/src/views/settings/GatewaySettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>Gateway Settings</h2>
+    <p>Gateway configuration options.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/GeneralSettings.vue
+++ b/frontend/src/views/settings/GeneralSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>General Settings</h2>
+    <p>Configure general parameters here.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/GroupsSettings.vue
+++ b/frontend/src/views/settings/GroupsSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>Groups Settings</h2>
+    <p>Manage your groups here.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/NodesSettings.vue
+++ b/frontend/src/views/settings/NodesSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>Nodes Settings</h2>
+    <p>Nodes configuration will appear here.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/ProfilesSettings.vue
+++ b/frontend/src/views/settings/ProfilesSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>Profiles Settings</h2>
+    <p>User profiles configuration.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>

--- a/frontend/src/views/settings/SystemSettings.vue
+++ b/frontend/src/views/settings/SystemSettings.vue
@@ -1,0 +1,9 @@
+<template>
+  <v-card class="pa-4">
+    <h2>System Settings</h2>
+    <p>System-wide configuration goes here.</p>
+  </v-card>
+</template>
+
+<script setup>
+</script>


### PR DESCRIPTION
## Summary
- add nested routing for settings sections
- create sidebar layout with categories
- move previous settings view to dashboard settings view
- add placeholder pages for additional sections

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bd51400e4832ebd8f262d0e1fbab8