### PR TITLE
Restore alarm settings page

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -9,8 +9,9 @@ This repository contains a LoRa node management platform composed of a **Node.js
   - WebSocket server for real‑time updates
   - Optional integrations: InfluxDB, email via Gmail and WhatsApp via Twilio
 - **Frontend** (`/frontend`)
-  - Vite + Vue 3 application with Vuetify
-  - Components to manage nodes on a map, dashboards and user settings
+- Vite + Vue 3 application with Vuetify
+- Components to manage nodes on a map, dashboards and user settings
+- Alert configuration page for email, Telegram and WhatsApp notifications
   - Communicates with the backend via REST and WebSocket
 
 The backend is started on port **3010** and exposes WebSocket events on the same port. The frontend uses Axios to talk to the API and Leaflet to display nodes and zones on a map.

--- a/frontend/src/views/settings/AlarmsSettings.vue
+++ b/frontend/src/views/settings/AlarmsSettings.vue
@@ -1,9 +1,9 @@
 <template>
-  <v-card class="pa-4">
-    <h2>Alarms Settings</h2>
-    <p>Configure alarms here.</p>
-  </v-card>
+  <v-container>
+    <AlertSettings />
+  </v-container>
 </template>
 
 <script setup>
+import AlertSettings from '@/components/AlertSettings.vue'
 </script>


### PR DESCRIPTION
## Summary
- reconnect alarms page with alert settings component
- document alerts page in overview

## Testing
- `npm test` in backend *(fails: no test specified)*
- `npm test` in frontend *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684be9c3fbd0832ea18d46c73c8b2551