### PR TITLE
Add draggable dashboard grid

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "vue-gauge": "^1.0.3",
         "vue-router": "^4.5.1",
         "vue-speedometer": "^3.0.1",
+        "vuedraggable": "^4.1.0",
         "vuetify": "^3.8.7"
       },
       "devDependencies": {
@@ -2739,6 +2740,12 @@
         "randombytes": "^2.1.0"
       }
     },
+    "node_modules/sortablejs": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.14.0.tgz",
+      "integrity": "sha512-pBXvQCs5/33fdN1/39pPL0NZF20LeRbLQ5jtnheIPN9JQAaufGjKdWduZn4U7wCtVuzKhmRkI0DFYHYRbB2H1w==",
+      "license": "MIT"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3137,6 +3144,18 @@
       },
       "peerDependencies": {
         "vue": "^3.3.0"
+      }
+    },
+    "node_modules/vuedraggable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-4.1.0.tgz",
+      "integrity": "sha512-FU5HCWBmsf20GpP3eudURW3WdWTKIbEIQxh9/8GE806hydR9qZqRRxRE3RjqX7PkuLuMQG/A7n3cfj9rCEchww==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.14.0"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.1"
       }
     },
     "node_modules/vuetify": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "vue-gauge": "^1.0.3",
     "vue-router": "^4.5.1",
     "vue-speedometer": "^3.0.1",
+    "vuedraggable": "^4.1.0",
     "vuetify": "^3.8.7"
   },
   "devDependencies": {

--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -1,13 +1,18 @@
 <template>
   <v-container>
-    <v-row>
-      <v-col
-        v-for="node in nodes"
-        :key="node.id"
-        cols="12"
-        :sm="columnSpan"
-        :md="columnSpan"
-      >
+    <draggable
+      v-model="localNodes"
+      item-key="id"
+      class="v-row d-flex flex-wrap"
+      :animation="200"
+      @update:modelValue="emitUpdate"
+    >
+      <template #item="{ element: node }">
+        <v-col
+          cols="12"
+          :sm="columnSpan"
+          :md="columnSpan"
+        >
         <v-card class="ma-2">
           <v-card-title class="d-flex justify-space-between align-center">
             {{ node.name }}
@@ -59,13 +64,15 @@
           </v-row>
         </v-card>
       </v-col>
-    </v-row>
+      </template>
+    </draggable>
   </v-container>
 </template>
 
 <script setup>
-import { defineProps, defineEmits, computed } from 'vue'
+import { defineProps, defineEmits, computed, ref, watch } from 'vue'
 import VueSpeedometer from 'vue-speedometer'
+import draggable from 'vuedraggable'
 
 const props = defineProps({
   nodes: { type: Array, default: () => [] },
@@ -73,6 +80,20 @@ const props = defineProps({
 })
 
 const columnSpan = computed(() => Math.floor(12 / props.perRow))
+
+const localNodes = ref([...props.nodes])
+
+watch(
+  () => props.nodes,
+  val => {
+    localNodes.value = [...val]
+  },
+  { deep: true }
+)
+
+const emitUpdate = () => {
+  emit('update:nodes', localNodes.value)
+}
 
 const emit = defineEmits(['toggle'])
 

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -29,6 +29,7 @@
           :nodes="panelNodes"
           :per-row="perRow"
           @toggle="toggleNode"
+          @update:nodes="panelNodes = $event"
         />
         <NodeList v-else-if="activeSection === 'list'" :nodes="nodes" />
         <NodeMap v-else-if="activeSection === 'map'" :nodes="nodes" />


### PR DESCRIPTION
## Summary
- enable draggable layout for nodes in dashboard
- handle node order updates in dashboard view
- include vuedraggable dependency

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bee5d2614832e8c6f1b630e4a9ee9