### PR TITLE
Add scaling option for node panel

### DIFF
--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -1,12 +1,13 @@
 <template>
-  <v-container>
-    <draggable
+  <div class="panel-scale" :style="wrapperStyle">
+    <v-container>
+      <draggable
       v-model="localNodes"
       item-key="id"
       class="v-row d-flex flex-wrap"
       :animation="200"
       @update:modelValue="emitUpdate"
-    >
+      >
       <template #item="{ element: node }">
         <v-col
           cols="12"
@@ -65,8 +66,9 @@
         </v-card>
       </v-col>
       </template>
-    </draggable>
-  </v-container>
+      </draggable>
+    </v-container>
+  </div>
 </template>
 
 <script setup>
@@ -76,10 +78,17 @@ import draggable from 'vuedraggable'
 
 const props = defineProps({
   nodes: { type: Array, default: () => [] },
-  perRow: { type: Number, default: 3 }
+  perRow: { type: Number, default: 3 },
+  scale: { type: Number, default: 1 }
 })
 
 const columnSpan = computed(() => Math.floor(12 / props.perRow))
+
+const wrapperStyle = computed(() => ({
+  transform: `scale(${props.scale})`,
+  transformOrigin: 'top left',
+  width: `${100 / props.scale}%`
+}))
 
 const localNodes = ref([...props.nodes])
 
@@ -106,3 +115,9 @@ const toggleButton = (node) => {
   toggleNode(node)
 }
 </script>
+
+<style scoped>
+.panel-scale {
+  overflow: visible;
+}
+</style>

--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -35,6 +35,16 @@
           label="Nodos por fila"
         ></v-slider>
 
+        <v-slider
+          v-model="localScale"
+          :min="0.5"
+          :max="2"
+          step="0.1"
+          thumb-label
+          class="mt-4"
+          label="Escala del panel"
+        ></v-slider>
+
         <v-text-field
           v-model="dashboardName"
           label="Nombre del dashboard"
@@ -93,6 +103,7 @@ import NodeSettings from './NodeSettings.vue'
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
   cols: { type: Number, default: 3 },
+  scale: { type: Number, default: 1 },
   dashboards: { type: Array, default: () => [] },
   defaultDash: { type: String, default: '' },
   nodes: { type: Array, default: () => [] },
@@ -103,6 +114,7 @@ const props = defineProps({
 const emit = defineEmits([
   'update:modelValue',
   'update:cols',
+  'update:scale',
   'save-dashboard',
   'load-dashboard',
   'update:defaultDash',
@@ -113,6 +125,7 @@ const emit = defineEmits([
 
 const localOpen = ref(props.modelValue)
 const localCols = ref(props.cols)
+const localScale = ref(props.scale)
 const dashboardName = ref('')
 const selectedDash = ref(props.defaultDash)
 const defaultDashLocal = ref(props.defaultDash)
@@ -126,12 +139,14 @@ const items = [
 
 watch(() => props.modelValue, v => (localOpen.value = v))
 watch(() => props.cols, v => (localCols.value = v))
+watch(() => props.scale, v => (localScale.value = v))
 watch(() => props.defaultDash, v => {
   selectedDash.value = v
   defaultDashLocal.value = v
 })
 watch(localOpen, v => emit('update:modelValue', v))
 watch(localCols, v => emit('update:cols', v))
+watch(localScale, v => emit('update:scale', v))
 watch(defaultDashLocal, v => emit('update:defaultDash', v))
 
 const save = () => {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -28,6 +28,7 @@
           v-if="activeSection === 'panel'"
           :nodes="panelNodes"
           :per-row="perRow"
+          :scale="panelScale"
           @toggle="toggleNode"
           @update:nodes="panelNodes = $event"
         />
@@ -54,10 +55,12 @@ const activeDashboard = ref('')
 const drawer = ref(false)
 const activeSection = inject('activeSection', ref('panel'))
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
+const panelScale = ref(parseFloat(localStorage.getItem('panelScale')) || 1)
 const selectedDashboard = ref('')
 const router = useRouter()
 
 watch(perRow, val => localStorage.setItem('perRow', val))
+watch(panelScale, val => localStorage.setItem('panelScale', val))
 let firstLoad = true
 
 watch(panelNodes, async val => {

--- a/frontend/src/views/settings/DashboardSettings.vue
+++ b/frontend/src/views/settings/DashboardSettings.vue
@@ -3,12 +3,14 @@
     <PanelSettings
       v-model="open"
       :cols="perRow"
+      :scale="panelScale"
       :dashboards="Object.keys(dashboards.layouts)"
       :default-dash="dashboards.default"
       :nodes="nodes"
       :panel-nodes="panelNodes"
       full-page
       @update:cols="perRow = $event"
+      @update:scale="panelScale = $event"
       @save-dashboard="saveDashboard"
       @load-dashboard="loadDashboard"
       @update:defaultDash="setDefaultDashboard"
@@ -30,9 +32,11 @@ const panelNodes = ref([])
 const dashboards = ref({ default: '', layouts: {} })
 const activeDashboard = ref('')
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
+const panelScale = ref(parseFloat(localStorage.getItem('panelScale')) || 1)
 const selectedDashboard = ref('')
 
 watch(perRow, val => localStorage.setItem('perRow', val))
+watch(panelScale, val => localStorage.setItem('panelScale', val))
 let firstLoad = true
 
 watch(panelNodes, async val => {


### PR DESCRIPTION
## Summary
- allow scaling of the entire NodePanel via new `scale` prop
- expose panel scale control in PanelSettings
- persist and apply panel scale in dashboard views

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bf2b12090832e901abe6a12349398