### PR TITLE
Permitir más nodos por fila

### DIFF
--- a/frontend/src/components/PanelSettings.vue
+++ b/frontend/src/components/PanelSettings.vue
@@ -29,7 +29,7 @@
         <v-slider
           v-model="localCols"
           :min="1"
-          :max="4"
+          :max="12"
           step="1"
           thumb-label
           label="Nodos por fila"


### PR DESCRIPTION
## Summary
- allow up to 12 nodes per row in dashboard settings

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_684bf9b928c0832eb50f35ee1788a668