### PR TITLE
Scale-aware grid width for dashboard

### DIFF
--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -82,7 +82,10 @@ const props = defineProps({
   scale: { type: Number, default: 1 }
 })
 
-const columnSpan = computed(() => Math.floor(12 / props.perRow))
+const columnSpan = computed(() => {
+  const columns = Math.max(1, Math.floor(props.perRow / props.scale))
+  return Math.floor(12 / columns)
+})
 
 const wrapperStyle = computed(() => ({
   transform: `scale(${props.scale})`,


### PR DESCRIPTION
## Summary
- dynamically compute dashboard column span based on scale

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c03dcb944832e9f9853c51871896e