### PR TITLE
Fix node panel container

### DIFF
--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="panel-scale">
-    <v-container>
+  <div class="panel-scale fill-height">
+    <v-container fluid class="fill-height">
       <draggable
       v-model="localNodes"
       item-key="id"
@@ -122,5 +122,7 @@ const toggleButton = (node) => {
 <style scoped>
 .panel-scale {
   overflow: visible;
+  width: 100%;
+  height: 100%;
 }
 </style>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -10,7 +10,7 @@
       />
 
       <v-main>
-      <v-container>
+      <v-container fluid class="fill-height">
         <v-row>
           <v-col cols="12">
             <v-tabs v-model="activeDashboard" class="mb-4">


### PR DESCRIPTION
## Summary
- keep NodePanel container full width and height
- ensure DashboardView's container expands to available space

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c1184b300832e8860614848bbf88a