### PR TITLE
Improve dashboard grid layout

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -28,6 +28,7 @@
           v-if="activeSection === 'panel'"
           :nodes="panelNodes"
           :scale="panelScale"
+          :per-row="perRow"
           @toggle="toggleNode"
           @update:nodes="panelNodes = $event"
         />


### PR DESCRIPTION
## Summary
- adjust dashboard grid to keep nodes aligned
- pass per-row setting to NodeGrid
- prevent node overlap and increase node height for gauges

## Testing
- `npm run build` in `frontend`
- `npm test` in `backend` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d2e7e0058832ea59e823d6913acb1