### PR TITLE
Fix NodeGrid spacing recalculation

### DIFF
--- a/frontend/src/components/NodeGrid.vue
+++ b/frontend/src/components/NodeGrid.vue
@@ -99,18 +99,21 @@ const offsetX = ref(0)
 const offsetY = ref(0)
 
 const NODE_WIDTH = 240
-const NODE_HEIGHT = 260
+const NODE_HEIGHT = 280
 const DEFAULT_GRID = 260
+const BASE_SPACING = 20
 
 const nodeWidth = computed(() => NODE_WIDTH * props.scale)
 const nodeHeight = computed(() => NODE_HEIGHT * props.scale)
 
 const gridWidth = ref(0)
 const gridSize = computed(() => {
-  if (!gridWidth.value || !props.perRow) return DEFAULT_GRID * props.scale
-  return (gridWidth.value / props.perRow)
+  const minSize = nodeWidth.value + BASE_SPACING * props.scale
+  if (!gridWidth.value || !props.perRow) return Math.max(minSize, DEFAULT_GRID * props.scale)
+  return Math.max(gridWidth.value / props.perRow, minSize)
 })
 const spacing = computed(() => gridSize.value - nodeWidth.value)
+const gridSizeY = computed(() => nodeHeight.value + spacing.value)
 
 function updateGridWidth() {
   gridWidth.value = gridRef.value?.clientWidth || 0
@@ -123,14 +126,14 @@ onMounted(() => {
 onUnmounted(() => window.removeEventListener('resize', updateGridWidth))
 
 const gridStyle = computed(() => ({
-  backgroundSize: `${gridSize.value}px ${gridSize.value}px`
+  backgroundSize: `${gridSize.value}px ${gridSizeY.value}px`
 }))
 
 function getItemStyle(node) {
   const offset = spacing.value / 2
   return {
     left: node.xIndex * gridSize.value + offset + 'px',
-    top: node.yIndex * gridSize.value + offset + 'px',
+    top: node.yIndex * gridSizeY.value + offset + 'px',
     width: NODE_WIDTH + 'px',
     height: NODE_HEIGHT + 'px',
     transform: `scale(${props.scale})`,
@@ -154,7 +157,7 @@ function onMouseMove(e) {
   x = Math.max(0, Math.min(x, rect.width - nodeWidth.value))
   y = Math.max(0, Math.min(y, rect.height - nodeHeight.value))
   const col = Math.round(x / gridSize.value)
-  const row = Math.round(y / gridSize.value)
+  const row = Math.round(y / gridSizeY.value)
   const occupied = localNodes.value.some(n => n !== dragging.value && n.xIndex === col && n.yIndex === row)
   if (!occupied) {
     dragging.value.xIndex = col
@@ -193,7 +196,7 @@ function toggleButton(node) {
 .grid-item {
   position: absolute;
   width: 240px;
-  height: 260px;
+  height: 280px;
   cursor: move;
 }
 .node-card {


### PR DESCRIPTION
## Summary
- adjust node height and sizing to show gauge fully
- keep spacing in sync on both axes and recalc with scale changes

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d318936a0832ea499cd0dffc93d04