### PR TITLE
Adjust dashboard visuals

### DIFF
--- a/frontend/src/components/NodeGrid.vue
+++ b/frontend/src/components/NodeGrid.vue
@@ -37,7 +37,7 @@
             <div class="text-body-2">{{ node.current ?? 'N/A' }} A</div>
           </v-col>
         </v-row>
-        <v-row class="pb-0 justify-center">
+        <v-row class="pb-0 justify-center mt-n4">
           <v-col cols="12" class="d-flex justify-center">
             <vue-speedometer
               :value="Number(node.current) || 0"
@@ -45,7 +45,7 @@
               :max-value="10"
               :needle-color="'#424242'"
               :ring-width="20"
-              :text-color="'#333'"
+              :text-color="'#fff'"
               :value-text-font-size="'22px'"
               :custom-segment-stops="[0, 7.5, 10]"
               :segment-colors="['#4caf50', '#fb8c00']"

--- a/frontend/src/components/NodePanel.vue
+++ b/frontend/src/components/NodePanel.vue
@@ -44,7 +44,7 @@
               <div class="text-body-2">{{ node.current ?? 'N/A' }} A</div>
             </v-col>
           </v-row>
-          <v-row class="pb-0 justify-center">
+          <v-row class="pb-0 justify-center mt-n4">
             <v-col cols="12" class="d-flex justify-center">
               <vue-speedometer
                 :value="Number(node.current) || 0"
@@ -52,7 +52,7 @@
                 :max-value="10"
                 :needle-color="'#424242'"
                 :ring-width="20"
-                :text-color="'#333'"
+                :text-color="'#fff'"
                 :value-text-font-size="'22px'"
                 :custom-segment-stops="[0, 7.5, 10]"
                 :segment-colors="['#4caf50', '#fb8c00']"

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -10,8 +10,8 @@
       />
 
       <v-main>
-      <v-container fluid class="fill-height">
-        <v-row>
+      <v-container fluid class="fill-height pt-0 dashboard-bg">
+        <v-row class="mt-0">
           <v-col cols="12">
             <v-tabs v-model="activeDashboard" class="mb-4">
               <v-tab
@@ -186,4 +186,10 @@ onMounted(() => {
   socket.addEventListener('message', fetchNodes)
 })
 </script>
+
+<style scoped>
+.dashboard-bg {
+  background-color: #f0f0f0;
+}
+</style>
 

--- a/frontend/src/views/settings/DashboardSettings.vue
+++ b/frontend/src/views/settings/DashboardSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-app>
+  <v-card class="pa-4">
     <PanelSettings
       v-model="open"
       :cols="perRow"
@@ -18,7 +18,7 @@
       @remove-node="removeFromPanel"
       @refresh-nodes="fetchNodes"
     />
-  </v-app>
+  </v-card>
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
- move gauge closer to readings and make gauge text white
- lift dashboard tab row up
- lighten dashboard background color
- restyle DashboardSettings like other settings

## Testing
- `npm run build` in frontend
- `npm test` in backend (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_684d3967f718832eb1095ad329eff0bd