### PR TITLE
UI tweaks for dashboard

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -11,8 +11,11 @@
 
       <v-main>
       <v-container fluid class="fill-height pt-0 dashboard-bg">
-        <v-row class="mt-0">
-          <v-col cols="12">
+        <v-row
+          v-if="activeSection === 'panel'"
+          class="mt-0 align-center dashboard-tabs"
+        >
+          <v-col>
             <v-tabs v-model="activeDashboard" class="mb-4">
               <v-tab
                 v-for="(layout, name) in dashboards.layouts"
@@ -22,6 +25,15 @@
                 {{ name }}
               </v-tab>
             </v-tabs>
+          </v-col>
+          <v-col cols="auto">
+            <v-select
+              v-model="panelScale"
+              :items="scaleOptions"
+              label="Escala"
+              density="compact"
+              style="max-width: 100px"
+            />
           </v-col>
         </v-row>
         <NodeGrid
@@ -56,6 +68,7 @@ const drawer = ref(false)
 const activeSection = inject('activeSection', ref('panel'))
 const perRow = ref(parseInt(localStorage.getItem('perRow')) || 3)
 const panelScale = ref(parseFloat(localStorage.getItem('panelScale')) || 1)
+const scaleOptions = Array.from({ length: 10 }, (_, i) => (i + 1) * 0.2)
 const selectedDashboard = ref('')
 const router = useRouter()
 
@@ -190,6 +203,12 @@ onMounted(() => {
 <style scoped>
 .dashboard-bg {
   background-color: #000;
+}
+.dashboard-tabs {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: white;
 }
 </style>
 

--- a/frontend/src/views/settings/DashboardSettings.vue
+++ b/frontend/src/views/settings/DashboardSettings.vue
@@ -1,24 +1,22 @@
 <template>
-  <v-card class="pa-4">
-    <PanelSettings
-      v-model="open"
-      :cols="perRow"
-      :scale="panelScale"
-      :dashboards="Object.keys(dashboards.layouts)"
-      :default-dash="dashboards.default"
-      :nodes="nodes"
-      :panel-nodes="panelNodes"
-      full-page
-      @update:cols="perRow = $event"
-      @update:scale="panelScale = $event"
-      @save-dashboard="saveDashboard"
-      @load-dashboard="loadDashboard"
-      @update:defaultDash="setDefaultDashboard"
-      @add-node="addToPanel"
-      @remove-node="removeFromPanel"
-      @refresh-nodes="fetchNodes"
-    />
-  </v-card>
+  <PanelSettings
+    v-model="open"
+    :cols="perRow"
+    :scale="panelScale"
+    :dashboards="Object.keys(dashboards.layouts)"
+    :default-dash="dashboards.default"
+    :nodes="nodes"
+    :panel-nodes="panelNodes"
+    full-page
+    @update:cols="perRow = $event"
+    @update:scale="panelScale = $event"
+    @save-dashboard="saveDashboard"
+    @load-dashboard="loadDashboard"
+    @update:defaultDash="setDefaultDashboard"
+    @add-node="addToPanel"
+    @remove-node="removeFromPanel"
+    @refresh-nodes="fetchNodes"
+  />
 </template>
 
 <script setup>


### PR DESCRIPTION
## Summary
- move dashboard tabs directly below the top bar
- hide dashboard tabs when listing nodes
- add scale dropdown in dashboard view
- remove outer card on dashboard settings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d5eff2150832ea4945d50aca13654