### PR TITLE
Fix dashboard tabs background color for dark theme

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -208,7 +208,8 @@ onMounted(() => {
   position: sticky;
   top: 0;
   z-index: 1;
-  background: white;
+  /* Match global dark theme */
+  background: #242424;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- update dashboard tabs to use dark background color consistent with theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d6942cd44832e994aba0c5e00a925