### PR TITLE
Add pan and zoom support to NodeGrid

### DIFF
--- a/frontend/src/components/NodeGrid.vue
+++ b/frontend/src/components/NodeGrid.vue
@@ -1,13 +1,21 @@
 <template>
-  <div class="grid" ref="gridRef" :style="gridStyle">
-    <div
-      v-for="node in localNodes"
-      :key="node.id"
-      class="grid-item"
-      :style="getItemStyle(node)"
-      @mousedown="startDrag(node, $event)"
-    >
-      <v-card class="node-card">
+  <div
+    class="grid-container"
+    ref="containerRef"
+    :style="containerStyle"
+    @wheel.prevent="onWheel"
+    @mousedown="startPan"
+    @touchstart="onTouchStart"
+  >
+    <div class="grid" ref="gridRef" :style="gridStyle">
+      <div
+        v-for="node in localNodes"
+        :key="node.id"
+        class="grid-item"
+        :style="getItemStyle(node)"
+        @mousedown.stop="startDrag(node, $event)"
+      >
+        <v-card class="node-card">
         <v-card-title class="d-flex justify-space-between align-center">
           {{ node.name }}
           <v-btn
@@ -58,6 +66,7 @@
         </v-row>
       </v-card>
     </div>
+    </div>
   </div>
 </template>
 
@@ -67,7 +76,7 @@ import VueSpeedometer from 'vue-speedometer'
 
 const props = defineProps({
   nodes: { type: Array, default: () => [] },
-  scale: { type: Number, default: 1 },
+  nodeScale: { type: Number, default: 1 },
   perRow: { type: Number, default: 3 }
 })
 
@@ -93,27 +102,47 @@ watch(
   { deep: true }
 )
 
+const containerRef = ref(null)
 const gridRef = ref(null)
+const translateX = ref(0)
+const translateY = ref(0)
+const scale = ref(1)
+const panning = ref(false)
+let startPanX = 0
+let startPanY = 0
+let pinchDistance = 0
+let pinchStartScale = 1
 const dragging = ref(null)
 const offsetX = ref(0)
 const offsetY = ref(0)
+
+let savedView = {}
+try { savedView = JSON.parse(localStorage.getItem('panelView') || '{}') } catch {}
+translateX.value = savedView.x || 0
+translateY.value = savedView.y || 0
+scale.value = savedView.scale || 1
 
 const NODE_WIDTH = 240
 const NODE_HEIGHT = 280
 const DEFAULT_GRID = 260
 const BASE_SPACING = 20
 
-const nodeWidth = computed(() => NODE_WIDTH * props.scale)
-const nodeHeight = computed(() => NODE_HEIGHT * props.scale)
+const nodeWidth = computed(() => NODE_WIDTH * props.nodeScale)
+const nodeHeight = computed(() => NODE_HEIGHT * props.nodeScale)
 
 const gridWidth = ref(0)
 const gridSize = computed(() => {
-  const minSize = nodeWidth.value + BASE_SPACING * props.scale
-  if (!gridWidth.value || !props.perRow) return Math.max(minSize, DEFAULT_GRID * props.scale)
+  const minSize = nodeWidth.value + BASE_SPACING * props.nodeScale
+  if (!gridWidth.value || !props.perRow) return Math.max(minSize, DEFAULT_GRID * props.nodeScale)
   return Math.max(gridWidth.value / props.perRow, minSize)
 })
 const spacing = computed(() => gridSize.value - nodeWidth.value)
 const gridSizeY = computed(() => nodeHeight.value + spacing.value)
+
+const containerStyle = computed(() => ({
+  transform: `translate(${translateX.value}px, ${translateY.value}px) scale(${scale.value})`,
+  transformOrigin: 'top left'
+}))
 
 function updateGridWidth() {
   gridWidth.value = gridRef.value?.clientWidth || 0
@@ -124,6 +153,11 @@ onMounted(() => {
   window.addEventListener('resize', updateGridWidth)
 })
 onUnmounted(() => window.removeEventListener('resize', updateGridWidth))
+
+watch([translateX, translateY, scale], () => {
+  const view = { x: translateX.value, y: translateY.value, scale: scale.value }
+  localStorage.setItem('panelView', JSON.stringify(view))
+})
 
 const gridStyle = computed(() => ({
   backgroundSize: `${gridSize.value}px ${gridSizeY.value}px`
@@ -136,15 +170,15 @@ function getItemStyle(node) {
     top: node.yIndex * gridSizeY.value + offset + 'px',
     width: NODE_WIDTH + 'px',
     height: NODE_HEIGHT + 'px',
-    transform: `scale(${props.scale})`,
+    transform: `scale(${props.nodeScale})`,
     transformOrigin: 'top left'
   }
 }
 
 function startDrag(node, e) {
   dragging.value = node
-  offsetX.value = e.offsetX
-  offsetY.value = e.offsetY
+  offsetX.value = e.offsetX / (props.nodeScale * scale.value)
+  offsetY.value = e.offsetY / (props.nodeScale * scale.value)
   document.addEventListener('mousemove', onMouseMove)
   document.addEventListener('mouseup', stopDrag)
 }
@@ -152,10 +186,12 @@ function startDrag(node, e) {
 function onMouseMove(e) {
   if (!dragging.value || !gridRef.value) return
   const rect = gridRef.value.getBoundingClientRect()
-  let x = e.clientX - rect.left - offsetX.value
-  let y = e.clientY - rect.top - offsetY.value
-  x = Math.max(0, Math.min(x, rect.width - nodeWidth.value))
-  y = Math.max(0, Math.min(y, rect.height - nodeHeight.value))
+  let x = (e.clientX - rect.left) / scale.value - offsetX.value
+  let y = (e.clientY - rect.top) / scale.value - offsetY.value
+  const maxX = gridRef.value.clientWidth - nodeWidth.value
+  const maxY = gridRef.value.clientHeight - nodeHeight.value
+  x = Math.max(0, Math.min(x, maxX))
+  y = Math.max(0, Math.min(y, maxY))
   const col = Math.round(x / gridSize.value)
   const row = Math.round(y / gridSizeY.value)
   const occupied = localNodes.value.some(n => n !== dragging.value && n.xIndex === col && n.yIndex === row)
@@ -180,18 +216,97 @@ function toggleButton(node) {
   node.state = !node.state
   toggleNode(node)
 }
+
+function startPan(e) {
+  if (e.button !== undefined && e.button !== 0) return
+  panning.value = true
+  startPanX = e.clientX
+  startPanY = e.clientY
+  document.addEventListener('mousemove', onPanMove)
+  document.addEventListener('mouseup', stopPan)
+}
+
+function onPanMove(e) {
+  if (!panning.value) return
+  translateX.value += e.clientX - startPanX
+  translateY.value += e.clientY - startPanY
+  startPanX = e.clientX
+  startPanY = e.clientY
+}
+
+function stopPan() {
+  panning.value = false
+  document.removeEventListener('mousemove', onPanMove)
+  document.removeEventListener('mouseup', stopPan)
+}
+
+function onWheel(e) {
+  const delta = e.deltaY > 0 ? -0.1 : 0.1
+  scale.value = Math.min(3, Math.max(0.5, scale.value + delta))
+}
+
+function onTouchStart(e) {
+  if (e.touches.length === 1) {
+    panning.value = true
+    startPanX = e.touches[0].clientX
+    startPanY = e.touches[0].clientY
+    document.addEventListener('touchmove', onTouchMove)
+    document.addEventListener('touchend', onTouchEnd)
+  } else if (e.touches.length === 2) {
+    pinchDistance = getDistance(e.touches)
+    pinchStartScale = scale.value
+    document.addEventListener('touchmove', onTouchMove)
+    document.addEventListener('touchend', onTouchEnd)
+  }
+}
+
+function onTouchMove(e) {
+  if (e.touches.length === 1 && panning.value) {
+    translateX.value += e.touches[0].clientX - startPanX
+    translateY.value += e.touches[0].clientY - startPanY
+    startPanX = e.touches[0].clientX
+    startPanY = e.touches[0].clientY
+  } else if (e.touches.length === 2) {
+    const dist = getDistance(e.touches)
+    if (pinchDistance) {
+      scale.value = Math.min(3, Math.max(0.5, pinchStartScale * dist / pinchDistance))
+    }
+  }
+}
+
+function onTouchEnd(e) {
+  if (e.touches.length === 0) {
+    panning.value = false
+    document.removeEventListener('touchmove', onTouchMove)
+    document.removeEventListener('touchend', onTouchEnd)
+  }
+  if (e.touches.length < 2) {
+    pinchDistance = 0
+  }
+}
+
+function getDistance(touches) {
+  const dx = touches[0].clientX - touches[1].clientX
+  const dy = touches[0].clientY - touches[1].clientY
+  return Math.sqrt(dx * dx + dy * dy)
+}
 </script>
 
 <style scoped>
-.grid {
+.grid-container {
   position: relative;
   width: 100%;
   height: 650px;
+  overflow: hidden;
+}
+.grid {
+  position: relative;
+  width: 100%;
+  height: 100%;
   background-color: #f5f5f5;
   background-image:
     linear-gradient(to right, #e0e0e0 1px, transparent 1px),
     linear-gradient(to bottom, #e0e0e0 1px, transparent 1px);
-  overflow: hidden;
 }
 .grid-item {
   position: absolute;

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -39,7 +39,7 @@
         <NodeGrid
           v-if="activeSection === 'panel'"
           :nodes="panelNodes"
-          :scale="panelScale"
+          :node-scale="panelScale"
           :per-row="perRow"
           @toggle="toggleNode"
           @update:nodes="panelNodes = $event"


### PR DESCRIPTION
## Summary
- allow panning and zooming the node grid
- keep individual node dragging working
- pass renamed `node-scale` prop from dashboard

## Testing
- `npm run build` in frontend
- `npm test` in backend *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d9cc07ae4832e9f3e2bc6efecb0ba